### PR TITLE
Sprint 4 — correctness fixes + release prep (0.1.0b1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,103 @@
+# Changelog
+
+All notable changes to this project are documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project follows [PEP 440](https://peps.python.org/pep-0440/) version
+identifiers (a Python-flavoured variant of [Semantic Versioning](https://semver.org/)
+that supports `bN` pre-releases).
+
+## [Unreleased]
+
+## [0.1.0b1] - 2026-06-02
+
+First public **beta** of the refactored library. This entry covers the whole
+`0.0.12` → `0.1.0` delta: `0.0.12` is the last pre-refactor release on PyPI and
+serves as the baseline. As a pre-release, `0.1.0b1` is **not** installed by
+default — use `pip install --pre pyetnic`. Existing `0.0.12` users are not
+auto-upgraded, so the refactored library can be beta-tested without disruption.
+
+### Added
+
+- **Public `pyetnic.eprom` and `pyetnic.seps` namespaces** as the supported
+  import surface. All public functions, data models and exceptions are imported
+  from these two namespaces.
+- **Opt-in strict error mode.** `strict_errors()` context manager and the
+  `Config.RAISE_ON_ERROR` flag make EPROM functions raise typed exceptions
+  instead of returning `None`. The flag is backed by a `ContextVar`, so it is
+  safe under threads and asyncio (each thread/task sees its own value). The
+  default behaviour (return `None` on server error) is unchanged for backwards
+  compatibility and is planned to flip to "raise" in `0.2.0`.
+- **Typed exception hierarchy** rooted at `EtnicError`:
+  `EtnicTransportError` (network/SOAP failures) and `EtnicBusinessError`
+  (server-side `success=False` refusals), the latter specialised into
+  `EtnicDocumentNotAccessibleError`, `EtnicNotFoundError` and
+  `EtnicValidationError`.
+- **`EtnicAlreadyApprovedError`** (ETNIC codes 1530 / 1545) and
+  **`EtnicConcurrencyError`** (code 00011) exception classes, exported from the
+  top-level package and the `eprom` namespace.
+- **ETNIC error-code routing.** `map_etnic_error_code_to_class` now maps the
+  full ETNIC error catalogue (~60 codes across the EPROM services, via a
+  discrete table plus inclusive numeric ranges) onto the specialised
+  `EtnicBusinessError` subclasses. Codes that are not client-fixable (00025
+  security, 00999 internal SQL) deliberately stay on the base class.
+- **Typed nomenclature Enums** (all `(str, Enum)`, so members compare equal to
+  their raw string value): `TypeInterventionExterieure`, `CodeAdmission`,
+  `CodeSanction`, `MotifAbandon`, `DureeInoccupation`, `SituationMenage`.
+- **`py.typed` marker (PEP 561).** The package now ships inline type information
+  to downstream type checkers.
+- **Optional-dependency extras.** `[seps]` pulls in `xmlsec` for the SEPS X509
+  signing path; `[excel]` pulls in `openpyxl`.
+
+### Changed
+
+- **`Config.ETAB_ID` and `Config.IMPL_ID` now return `int`** (previously `str`).
+  A widening change: integer identifiers no longer need to be cast at call
+  sites.
+- **Business-error messages surface the real ETNIC code and description.**
+  `str(exc)` now reads `ETNIC error {code}: {description}` (e.g. `ETNIC error
+  30004: Le type d'intervention extérieure est incorrect`) instead of a generic
+  "response was empty or success=False" placeholder.
+- **Request serialization consolidated** behind internal helpers
+  (`to_soap_dict`, `organisation_request_id`) shared across the EPROM document
+  and SEPS write services.
+- **Library logging** uses lazy `%s` formatting throughout, and verbose
+  `pformat()` debug dumps are guarded by `logger.isEnabledFor(DEBUG)` so they
+  cost nothing when debug logging is off.
+
+### Fixed
+
+- **`TypeInterventionExterieure` Enum values corrected** from long French labels
+  to the single-letter codes ETNIC actually accepts
+  (`A, B, C, D, E, F, I, J, K, P, Q, U, V`). The previous label values
+  (e.g. `"Convention"`) were rejected by ETNIC with code 30004; the letter codes
+  (e.g. `"C"`) are accepted. Enum member names are unchanged, and
+  `TYPES_INTERVENTION_EXTERIEURE` auto-derives from the corrected values.
+- **Single-element zeep collections are normalised correctly.** A shared
+  `_as_list()` helper unifies the `None` / single-`dict` / `list` shapes zeep
+  returns, fixing parsers that could mis-handle a one-element result (notably
+  `lister_formations_organisables` and the Document 1/2/3 readers).
+- **SEPS Inscriptions README example** no longer imports three non-existent
+  symbols (`SepsDroitInscriptionSave`, `SepsAdmissionSave`, `SepsSanctionSave`),
+  which raised `ImportError` on copy-paste.
+
+### Removed
+
+- **`requirements.txt`** — dependencies are declared in `pyproject.toml`;
+  install with `pip install pyetnic` plus the extras you need.
+- **`openpyxl` from the base dependencies** — moved to the `[excel]` extra. The
+  base install is lighter; install `pyetnic[excel]` for the Excel export path.
+- **`pyetnic/resources/Codes_Pays.xls`** — an unused 83 KB binary resource.
+
+### Deprecated
+
+- **`SoapError`** — a backwards-compatible alias for `EtnicTransportError`.
+  Existing `except SoapError` code keeps working; the alias will be removed in
+  `1.0.0`.
+- **`TYPES_INTERVENTION_EXTERIEURE`** — the legacy list constant, superseded by
+  the `TypeInterventionExterieure` Enum. Scheduled for removal in `1.0.0`.
+- **The flat top-level namespace** (`pyetnic.lire_organisation`, …) — no longer
+  documented. Import from `pyetnic.eprom` / `pyetnic.seps` instead.
+
+[Unreleased]: https://github.com/Lapin-Blanc/pyetnic/compare/v0.1.0b1...HEAD
+[0.1.0b1]: https://github.com/Lapin-Blanc/pyetnic/compare/v0.0.12...v0.1.0b1

--- a/docs/PUBLIC_API_SURFACE.md
+++ b/docs/PUBLIC_API_SURFACE.md
@@ -102,7 +102,9 @@ All use `(str, Enum)` base — members compare equal to their raw string value.
 | `EtnicBusinessError` | Server-side refusals (`success=False`) |
 | `EtnicDocumentNotAccessibleError` | Doc1/Doc2/Doc3 workflow violation (e.g. error 20102) |
 | `EtnicNotFoundError` | Resource not found (e.g. error 00009) |
-| `EtnicValidationError` | Input rejected by validation |
+| `EtnicValidationError` | Input rejected by validation (most `20xxx`/`30xxx` codes, `4004`-`4012`, …) |
+| `EtnicAlreadyApprovedError` | Document already approved by the administration (codes 1530, 1545) |
+| `EtnicConcurrencyError` | Record modified by another user since read (code 00011) |
 | `SoapError` | **Deprecated** alias for `EtnicTransportError`. Will be removed in 1.0.0 |
 
 ---

--- a/docs/phases/sprint-4-publication/PUBLICATION_CHECKLIST.md
+++ b/docs/phases/sprint-4-publication/PUBLICATION_CHECKLIST.md
@@ -12,20 +12,18 @@ exploratory).
 
 ## Prerequisites (gather before 4.5)
 
-> **Publishing model (piste A)**: prod **PyPI upload is automated** by
+> **Publishing model (piste A)**: prod **PyPI upload is fully automated** by
 > `.github/workflows/publish-pypi.yml` — it fires on a `v*` tag and authenticates with
-> **OIDC Trusted Publishing** (no API token). We keep that for prod; the **TestPyPI dry-run is
-> manual** (local `twine`). See the OIDC check in Phase 4.5 before tagging.
+> **OIDC Trusted Publishing** (no API token, no manual upload). The pre-publish safety net is a
+> local `twine check` + a fresh-venv install of the built artifact — **no TestPyPI**.
 
 - [x] `pyetnic` on PyPI is **ours** (already published at `0.0.12`) — so 4.5 is an *update*.
-- [x] `pyetnic` is **free on TestPyPI** (claim it for the dry-run).
 - [x] Build tooling installed in the venv (`build` 1.5.0 + `twine` 6.2.0 — done in phase 4.4).
-- [ ] **Verify the PyPI Trusted Publisher** is registered for this repo (see "OIDC check" in
-      Phase 4.5). With OIDC in place a prod **PyPI API token is NOT needed** — the 0.0.12-era
-      token can be retired rather than regenerated.
-- [ ] **Create a TestPyPI account + token** (still required: the TestPyPI dry-run uses manual twine).
-- [ ] Store the TestPyPI token: `~/.pypirc` (`[testpypi]` section) **or** env
-      (`TWINE_USERNAME=__token__`, `TWINE_PASSWORD=pypi-…`). **Never commit tokens.**
+- [x] **PyPI Trusted Publisher verified** (checked 2026-06-02): GitHub · `Lapin-Blanc/pyetnic` ·
+      workflow `publish-pypi.yml` · environment `pypi`; GitHub `pypi` environment exists; no stale
+      token secret. OIDC fully configured — see the OIDC check in Phase 4.5.
+- [x] **No tokens to manage**: OIDC handles prod; with TestPyPI dropped there is no token to store.
+      The 0.0.12-era PyPI API token (if any) can be retired.
 
 ---
 
@@ -52,35 +50,41 @@ exploratory).
 - [ ] Verify `README.md` (484 lines) renders as the PyPI long description; check no broken local links.
 - [ ] Build + check: `.venv/bin/python -m build` then `.venv/bin/twine check dist/*`.
 
-## Phase 4.5 — Publish (piste A: manual TestPyPI dry-run → tag → CI publishes to PyPI)
+## Phase 4.5 — Publish (piste A: local install rehearsal → tag → CI publishes to PyPI)
 
-> **Split of responsibility (piste A)**: the **TestPyPI** upload is **manual** (local twine);
-> the **prod PyPI** upload is performed **by the workflow** when the `v0.1.0b1` tag is pushed.
-> Do **not** `twine upload` to prod yourself — that would collide with the tag-triggered run
-> (PyPI rejects the duplicate, whichever lands second).
+> **How prod publishing works (piste A)**: the **prod PyPI** upload is performed **by the
+> workflow** when the `v0.1.0b1` tag is pushed (clean-room rebuild + OIDC). Do **not** `twine
+> upload` to prod yourself — that would collide with the tag-triggered run (PyPI rejects the
+> duplicate, whichever lands second). The local rehearsal below uses **no upload**.
 
-### OIDC Trusted Publishing — verify once before tagging
+### OIDC Trusted Publishing — verified 2026-06-02 (re-check only if the workflow/repo/PyPI config changes)
 
-- [ ] **PyPI side** — open `https://pypi.org/manage/project/pyetnic/settings/publishing/`. Under
-      "Trusted Publishers", confirm a **GitHub** publisher with **exactly**: owner `Lapin-Blanc`,
-      repository `pyetnic`, workflow **filename** `publish-pypi.yml` (not the workflow's `name:`),
-      environment `pypi`. If absent → "Add a new publisher" with those four fields.
-- [ ] **GitHub side** — repo **Settings → Environments**: an environment named **`pypi`** exists
-      (case-sensitive; must match `environment: name: pypi` in the workflow). Optional hardening:
-      required reviewer and/or restrict deployments to the `v*` tag pattern.
-- [ ] Confirm **no stale `PYPI_API_TOKEN` secret** is wired into the publish step — OIDC needs none.
-- [ ] Safe failure mode: if OIDC is misconfigured the publish step fails at the auth handshake and
-      **nothing is uploaded** — fix the publisher registration, then re-run the job / re-push the tag.
+- [x] **PyPI side** — `https://pypi.org/manage/project/pyetnic/settings/publishing/`: a **GitHub**
+      publisher with owner `Lapin-Blanc`, repository `pyetnic`, workflow **filename**
+      `publish-pypi.yml`, environment `pypi`.
+- [x] **GitHub side** — repo **Settings → Environments**: the **`pypi`** environment exists
+      (matches `environment: name: pypi` in the workflow). Optional hardening (required reviewer /
+      `v*`-tag restriction) not yet applied.
+- [x] **No stale token** — publish step has no `with:`/`password`; `gh secret list` (repo) and
+      `gh secret list --env pypi` both empty.
+- [ ] Safe failure mode (for reference): if OIDC ever breaks, the publish step fails at the auth
+      handshake and **nothing is uploaded** — fix the publisher registration, then re-push the tag.
 
 ### Release steps
 
 - [ ] Merge `refactor/sprint-4` → `main` (PR), so the tag lands on the merge commit.
 - [ ] From `main`: clean build — `rm -rf dist/ && .venv/bin/python -m build`, then
       `.venv/bin/twine check dist/*`.
-- [ ] **TestPyPI dry-run (manual)**: `.venv/bin/twine upload --repository testpypi dist/*`.
-- [ ] Verify a **clean install in a fresh venv** from TestPyPI:
-      `pip install --pre --index-url https://test.pypi.org/simple/ --extra-index-url https://pypi.org/simple/ pyetnic[seps]`
-      then smoke-import and a no-network sanity call.
+- [ ] **Local install rehearsal (standard, no upload)** — install the built artifact in a fresh
+      throwaway venv and smoke-test it:
+      ```
+      python -m venv /tmp/pyetnic-rc && /tmp/pyetnic-rc/bin/pip install "dist/pyetnic-0.1.0b1-py3-none-any.whl[seps]"
+      /tmp/pyetnic-rc/bin/python -c "import pyetnic; print(pyetnic.__version__)"
+      /tmp/pyetnic-rc/bin/pyetnic --help    # entry point
+      ```
+      Exercises deps + the `[seps]` extra (needs `libxml2-dev`/`libxmlsec1-dev` for `xmlsec`),
+      the import, and the CLI entry point. Repeat against the `.tar.gz` sdist to also test the
+      source build.
 - [ ] **Tag → triggers the prod publish**: `git tag v0.1.0b1 && git push origin v0.1.0b1`
       (on the `main` merge commit). The workflow rebuilds in a clean room, re-runs `twine check`,
       and publishes to **prod PyPI** via OIDC. **No manual prod `twine upload`.**
@@ -91,7 +95,10 @@ exploratory).
 
 ## Notes
 
-- **Irreversibility**: PyPI uploads cannot be overwritten or deleted (only *yanked*). The TestPyPI
-  dry-run + `twine check` are the safety net.
+- **Irreversibility**: PyPI uploads cannot be overwritten or deleted (only *yanked*). The
+  `twine check` + the local fresh-venv install of the built artifact are the safety net. TestPyPI
+  was dropped from piste A: it rehearses a manual upload path that prod no longer uses (prod is
+  CI/OIDC), `twine check` already covers metadata/README, and the local install covers
+  deps/extras/import/CLI — the parts that actually break.
 - **Beta semantics**: `0.1.0b1` is a pre-release — existing `0.0.12` users are **not** auto-upgraded
   (`--pre` required). Intentional: lets the refactored library be beta-tested without disrupting them.

--- a/docs/phases/sprint-4-publication/PUBLICATION_CHECKLIST.md
+++ b/docs/phases/sprint-4-publication/PUBLICATION_CHECKLIST.md
@@ -1,0 +1,65 @@
+# Sprint 4 — Publication checklist (phases 4.3 → 4.5)
+
+Per the hybrid plan: phases 4.1/4.2 have full recipes; the publication mechanics (4.3-4.5) are
+driven by this checklist rather than rigid recipes (they are environment-dependent and partly
+exploratory).
+
+> **Key sequencing**: publish from **`main`, post-merge**, not from the feature branch. Land
+> 4.1-4.4 on `refactor/sprint-4` → PR → merge → then cut the release (4.5) from `main`, so the
+> `v0.1.0b1` tag points at the merge commit.
+
+---
+
+## Prerequisites (gather before 4.5)
+
+- [x] `pyetnic` on PyPI is **ours** (already published at `0.0.12`) — so 4.5 is an *update*.
+- [x] `pyetnic` is **free on TestPyPI** (claim it for the dry-run).
+- [ ] **Regenerate a PyPI API token** scoped to the `pyetnic` project (the 0.0.12-era token may be stale).
+- [ ] **Create a TestPyPI account + token** (separate credentials from PyPI).
+- [ ] Choose token storage: `~/.pypirc` (`[pypi]` / `[testpypi]` sections) **or** env
+      (`TWINE_USERNAME=__token__`, `TWINE_PASSWORD=pypi-…`). **Never commit tokens.**
+- [ ] Install build tooling in the venv: `.venv/bin/pip install build twine` (neither is present).
+
+---
+
+## Phase 4.3 — CHANGELOG.md
+
+- [ ] Create `CHANGELOG.md` (Keep a Changelog format: Added / Changed / Fixed / Removed).
+- [ ] The `0.1.0b1` entry covers the **whole `0.0.12` → `0.1.0` delta** (Sprints 0→4 — `0.0.12` is
+      the pre-refactor baseline). Emphasize what a user sees:
+  - **Added**: strict error mode (`RAISE_ON_ERROR`), typed nomenclature Enums, typed exception
+    hierarchy + code routing (4.2), `py.typed`, `[seps]`/`[excel]` extras.
+  - **Changed**: `Config.ETAB_ID`/`IMPL_ID` return `int`; `_helpers` serialization.
+  - **Fixed**: `typeInterventionExterieure` Enum values (4.1); zeep list|dict normalization (Q8).
+  - **Removed**: `requirements.txt`, `Codes_Pays.xls`, `openpyxl` from base deps.
+- [ ] Note the pre-release install: `pip install --pre pyetnic`.
+
+## Phase 4.4 — Version bump + packaging metadata
+
+- [ ] Bump version in **both** places: `pyproject.toml:7` **and** `pyetnic/__init__.py:27`
+      (`0.0.12` → `0.1.0b1`). Consider deduplicating to one source (`dynamic = ["version"]`) later.
+- [ ] `classifiers`: `Development Status :: 3 - Alpha` → `4 - Beta`.
+- [ ] **Decide**: move `cryptography` from base `dependencies` into the `[seps]` extra (it is
+      SEPS-only per `CLAUDE.md`) — lightens the base install — or keep it (document why).
+- [ ] Enrich `[project.urls]`: add `Repository`, `Issues`, `Changelog` (only `Homepage` today).
+- [ ] Verify `README.md` (484 lines) renders as the PyPI long description; check no broken local links.
+- [ ] Build + check: `.venv/bin/python -m build` then `.venv/bin/twine check dist/*`.
+
+## Phase 4.5 — Publish (from `main`, post-merge)
+
+- [ ] TestPyPI dry-run: `twine upload --repository testpypi dist/*`.
+- [ ] Verify a **clean install in a fresh venv**:
+      `pip install --pre --index-url https://test.pypi.org/simple/ --extra-index-url https://pypi.org/simple/ pyetnic[seps]`
+      then smoke-import and a no-network sanity call.
+- [ ] Real upload: `twine upload dist/*`.
+- [ ] Tag and push: `git tag v0.1.0b1 && git push origin v0.1.0b1` (tag on the `main` merge commit).
+- [ ] Post-check: `pip install --pre pyetnic` from PyPI in a fresh venv.
+
+---
+
+## Notes
+
+- **Irreversibility**: PyPI uploads cannot be overwritten or deleted (only *yanked*). The TestPyPI
+  dry-run + `twine check` are the safety net.
+- **Beta semantics**: `0.1.0b1` is a pre-release — existing `0.0.12` users are **not** auto-upgraded
+  (`--pre` required). Intentional: lets the refactored library be beta-tested without disrupting them.

--- a/docs/phases/sprint-4-publication/PUBLICATION_CHECKLIST.md
+++ b/docs/phases/sprint-4-publication/PUBLICATION_CHECKLIST.md
@@ -12,13 +12,20 @@ exploratory).
 
 ## Prerequisites (gather before 4.5)
 
+> **Publishing model (piste A)**: prod **PyPI upload is automated** by
+> `.github/workflows/publish-pypi.yml` — it fires on a `v*` tag and authenticates with
+> **OIDC Trusted Publishing** (no API token). We keep that for prod; the **TestPyPI dry-run is
+> manual** (local `twine`). See the OIDC check in Phase 4.5 before tagging.
+
 - [x] `pyetnic` on PyPI is **ours** (already published at `0.0.12`) — so 4.5 is an *update*.
 - [x] `pyetnic` is **free on TestPyPI** (claim it for the dry-run).
-- [ ] **Regenerate a PyPI API token** scoped to the `pyetnic` project (the 0.0.12-era token may be stale).
-- [ ] **Create a TestPyPI account + token** (separate credentials from PyPI).
-- [ ] Choose token storage: `~/.pypirc` (`[pypi]` / `[testpypi]` sections) **or** env
+- [x] Build tooling installed in the venv (`build` 1.5.0 + `twine` 6.2.0 — done in phase 4.4).
+- [ ] **Verify the PyPI Trusted Publisher** is registered for this repo (see "OIDC check" in
+      Phase 4.5). With OIDC in place a prod **PyPI API token is NOT needed** — the 0.0.12-era
+      token can be retired rather than regenerated.
+- [ ] **Create a TestPyPI account + token** (still required: the TestPyPI dry-run uses manual twine).
+- [ ] Store the TestPyPI token: `~/.pypirc` (`[testpypi]` section) **or** env
       (`TWINE_USERNAME=__token__`, `TWINE_PASSWORD=pypi-…`). **Never commit tokens.**
-- [ ] Install build tooling in the venv: `.venv/bin/pip install build twine` (neither is present).
 
 ---
 
@@ -45,15 +52,40 @@ exploratory).
 - [ ] Verify `README.md` (484 lines) renders as the PyPI long description; check no broken local links.
 - [ ] Build + check: `.venv/bin/python -m build` then `.venv/bin/twine check dist/*`.
 
-## Phase 4.5 — Publish (from `main`, post-merge)
+## Phase 4.5 — Publish (piste A: manual TestPyPI dry-run → tag → CI publishes to PyPI)
 
-- [ ] TestPyPI dry-run: `twine upload --repository testpypi dist/*`.
-- [ ] Verify a **clean install in a fresh venv**:
+> **Split of responsibility (piste A)**: the **TestPyPI** upload is **manual** (local twine);
+> the **prod PyPI** upload is performed **by the workflow** when the `v0.1.0b1` tag is pushed.
+> Do **not** `twine upload` to prod yourself — that would collide with the tag-triggered run
+> (PyPI rejects the duplicate, whichever lands second).
+
+### OIDC Trusted Publishing — verify once before tagging
+
+- [ ] **PyPI side** — open `https://pypi.org/manage/project/pyetnic/settings/publishing/`. Under
+      "Trusted Publishers", confirm a **GitHub** publisher with **exactly**: owner `Lapin-Blanc`,
+      repository `pyetnic`, workflow **filename** `publish-pypi.yml` (not the workflow's `name:`),
+      environment `pypi`. If absent → "Add a new publisher" with those four fields.
+- [ ] **GitHub side** — repo **Settings → Environments**: an environment named **`pypi`** exists
+      (case-sensitive; must match `environment: name: pypi` in the workflow). Optional hardening:
+      required reviewer and/or restrict deployments to the `v*` tag pattern.
+- [ ] Confirm **no stale `PYPI_API_TOKEN` secret** is wired into the publish step — OIDC needs none.
+- [ ] Safe failure mode: if OIDC is misconfigured the publish step fails at the auth handshake and
+      **nothing is uploaded** — fix the publisher registration, then re-run the job / re-push the tag.
+
+### Release steps
+
+- [ ] Merge `refactor/sprint-4` → `main` (PR), so the tag lands on the merge commit.
+- [ ] From `main`: clean build — `rm -rf dist/ && .venv/bin/python -m build`, then
+      `.venv/bin/twine check dist/*`.
+- [ ] **TestPyPI dry-run (manual)**: `.venv/bin/twine upload --repository testpypi dist/*`.
+- [ ] Verify a **clean install in a fresh venv** from TestPyPI:
       `pip install --pre --index-url https://test.pypi.org/simple/ --extra-index-url https://pypi.org/simple/ pyetnic[seps]`
       then smoke-import and a no-network sanity call.
-- [ ] Real upload: `twine upload dist/*`.
-- [ ] Tag and push: `git tag v0.1.0b1 && git push origin v0.1.0b1` (tag on the `main` merge commit).
-- [ ] Post-check: `pip install --pre pyetnic` from PyPI in a fresh venv.
+- [ ] **Tag → triggers the prod publish**: `git tag v0.1.0b1 && git push origin v0.1.0b1`
+      (on the `main` merge commit). The workflow rebuilds in a clean room, re-runs `twine check`,
+      and publishes to **prod PyPI** via OIDC. **No manual prod `twine upload`.**
+- [ ] Watch the Actions run go green, then post-check: `pip install --pre pyetnic` from PyPI in a
+      fresh venv.
 
 ---
 

--- a/docs/phases/sprint-4-publication/phase-4.1-type-intervention-enum.md
+++ b/docs/phases/sprint-4-publication/phase-4.1-type-intervention-enum.md
@@ -1,0 +1,98 @@
+# Phase 4.1 — Fix `typeInterventionExterieure` Enum values (correctness)
+
+## Context
+
+The H9 Enum `TypeInterventionExterieure` (`pyetnic/nomenclatures.py`) stores **long French
+labels** (`"Convention"`, `"Agence Qualité"`, …). A live dev-server write/echo probe on
+2026-06-01 proved this is **wrong**:
+
+- `creer_organisation(typeInterventionExterieure="Convention")` → **rejected, code `30004`**
+  ("Le type d'intervention extérieure est incorrect").
+- `creer_organisation(typeInterventionExterieure="C")` → **accepted**, read back as `"C"`.
+
+ETNIC wants the **single-letter code**, not the label. Authoritative table:
+`specs/02_formation_organisation_v7.md` §"Valeurs de typeInterventionExterieure" (validated
+2025-06-10). The field is a free `xs:string` (not XSD-validated), so the Enum is convenience
+only — but its values must be the ones ETNIC accepts.
+
+This is **not a breaking change**: the Enum was added in Sprint 2 (H9), so it does not exist in
+the published `0.0.12`; and the old label values never worked against ETNIC.
+
+## Objective
+
+Replace the 13 Enum **values** (labels → single-letter codes), fix the now-falsified docstrings,
+and pin the values with tests. Member **names are unchanged** — only the right-hand-side values.
+
+## Tasks
+
+### 1. Swap the 13 values in `pyetnic/nomenclatures.py`
+
+| Member (unchanged) | Old value | New value |
+|---|---|---|
+| `PERSONNEL_NON_CHARGE_DE_COURS` | "Personnel non chargé de cours" | `"A"` |
+| `OCTROI_PERIODES_SUPPLEMENTAIRES_BONUS` | "Octroi périodes supplémentaires-bonus" | `"B"` |
+| `CONVENTION` | "Convention" | `"C"` |
+| `DISCRIMINATIONS_POSITIVES` | "Discriminations positives" | `"D"` |
+| `EHR` | "EHR" | `"E"` |
+| `FONDS_EUROPEENS` | "Fonds Européens" | `"F"` |
+| `FORMATION_PUBLICS_INFRA_SCOLARISES` | "Formation des publics infra scolarisés" | `"I"` |
+| `REORIENTATION_7TQ_7P` | "Réorientation 7TQ/7P" | `"J"` |
+| `OCTROI_PERIODES_CABINET_PROJETS_TRANSVER` | "Octroi périodes cabinet-projets transver" | `"K"` |
+| `FORMATIONS_CONTINUEES` | "Formations continuées" | `"P"` |
+| `AGENCE_QUALITE` | "Agence Qualité" | `"Q"` |
+| `UNION_EUROPEENNE` | "Union Européenne" | `"U"` |
+| `VALIDATION_DES_COMPETENCES` | "Validation des compétences" | `"V"` |
+
+Note: codes `R` (Récupération périodes) and `S` (CISCO Système) are **removed** by ETNIC and
+have no current member — do **not** add them. Reading a legacy org with value `"R"`/`"S"` still
+works (the dataclass stores the raw string; the Enum simply has no member for it).
+
+### 2. Fix the falsified docstrings
+
+In `nomenclatures.py`:
+- Module docstring (~lines 14-16): drop "these labels are what ETNIC expects verbatim" — replace
+  with "single-letter codes from the Organisation v7 manual (validated 2025-06-10); the XSD type
+  is a free `xs:string` so they are not contract-validated".
+- Class docstring + usage example (~lines 22-25): change `= "Convention"` to `= "C"`.
+
+`TYPES_INTERVENTION_EXTERIEURE` is derived from the Enum (`[m.value for m in …]`), so it updates
+automatically — verify, do not hand-edit.
+
+### 3. Update the pinned assertions in `tests/unit/test_nomenclatures.py`
+
+Lines ~19/27/28 assert `== "Convention"` (value and `(str, Enum)` equality both directions).
+Change them to `"C"`. These are your **red→green** signal.
+
+### 4. Add a drift-guard regression test
+
+Add a test that pins the full name→letter mapping (a dict literal compared against
+`{m.name: m.value for m in TypeInterventionExterieure}`) so a future edit cannot silently
+reintroduce labels.
+
+### 5. (Optional) Promote the probe to a guarded integration test
+
+Move `/tmp/probe_tie.py` into `tests/integration/eprom/test_type_intervention_integration.py`,
+gated on `Config.ETAB_ID`/`IMPL_ID` like the existing org fixture, asserting `"Convention"` →
+`EtnicBusinessError(code="30004")` and `"C"` → accepted. Optionally spot-check `"Q"` and the new
+`"J"` while you have the dev server, to confirm the spec table beyond `"C"`.
+
+### 6. Verify
+
+`.venv/bin/pytest tests/regression/ tests/unit/` — green.
+
+## Constraints
+
+- Member **names** unchanged; only values. `(str, Enum)` semantics preserved.
+- **Do not** confuse this field with Document 2's `coCatCol` (a separate two-level
+  type/sub-type system — see `specs/04_formation_periodes_v1.md`).
+- One commit: `fix(sprint-4): phase 4.1 — correct typeInterventionExterieure Enum to letter codes`.
+
+## Validation
+
+- [ ] 13 Enum values are single letters (A,B,C,D,E,F,I,J,K,P,Q,U,V)
+- [ ] `nomenclatures.py` docstrings no longer claim labels are expected verbatim
+- [ ] `TYPES_INTERVENTION_EXTERIEURE` now lists letters (auto-derived)
+- [ ] `test_nomenclatures.py` assertions updated to `"C"`
+- [ ] Drift-guard test added
+- [ ] (optional) Integration probe promoted; `"Convention"` → 30004 confirmed
+- [ ] Suite green

--- a/docs/phases/sprint-4-publication/phase-4.2-error-code-mapping.md
+++ b/docs/phases/sprint-4-publication/phase-4.2-error-code-mapping.md
@@ -1,0 +1,154 @@
+# Phase 4.2 — Error-code mapping enrichment (correctness)
+
+## Context
+
+`map_etnic_error_code_to_class` (`pyetnic/exceptions.py:116`) is an `if`-chain routing **only 2
+codes** (`20102` → `EtnicDocumentNotAccessibleError`, `00009` → `EtnicNotFoundError`); everything
+else falls through to the base `EtnicBusinessError`. `EtnicValidationError` **already exists**
+(`exceptions.py:103`) but is **never routed**.
+
+`specs/00_REGISTRE.md` §4 catalogues ~60 codes across the EPROM services. The 2026-06-01 probe
+showed a concrete symptom: code `30004` was raised as a generic `EtnicBusinessError` with the
+message `"Organisation response was empty or success=False"` — the real ETNIC description
+("Le type d'intervention extérieure est incorrect") was **masked**.
+
+Note: `signal_business_error` (`exceptions.py:170`) already extracts `code`/`description`/
+`request_id` via `extract_error_info` and already auto-builds a message — but callers pass an
+explicit generic `message=` that **overrides** the useful one. That is the masking cause.
+
+## Objective
+
+1. Route the full code catalogue to the right exception class.
+2. Add the two missing classes: `EtnicAlreadyApprovedError`, `EtnicConcurrencyError`.
+3. Stop masking the real ETNIC message (`str(exc)` must carry code + description).
+4. (Fold-in) Investigate the Common_v2 `requestId`-as-XML-attribute latent bug.
+
+All changes are **additive** (new classes subclass `EtnicBusinessError`), so existing
+`except EtnicBusinessError` / `except EtnicError` code keeps working. **Default mode is
+unchanged** (`RAISE_ON_ERROR == False` still returns `None`).
+
+## Tasks
+
+### 1. Add two exception classes (`exceptions.py`)
+
+```python
+class EtnicAlreadyApprovedError(EtnicBusinessError):
+    """The document is already approved by the administration.
+
+    Raised when an edit/approve operation targets a document ETNIC has
+    already locked as approved (codes 1530, 1545).
+    """
+
+
+class EtnicConcurrencyError(EtnicBusinessError):
+    """The record was modified by another user since it was read.
+
+    Optimistic-concurrency violation (code 00011) — re-read and retry.
+    """
+```
+
+### 2. Replace the `if`-chain with a table
+
+Discrete codes (string keys, leading zeros preserved):
+
+| Class | Codes |
+|---|---|
+| `EtnicNotFoundError` | `00009` |
+| `EtnicDocumentNotAccessibleError` | `20102`, `30003`, `30006` |
+| `EtnicAlreadyApprovedError` | `1530`, `1545` |
+| `EtnicConcurrencyError` | `00011` |
+| `EtnicValidationError` | `30001`, `30002`, `30004`, `30005`, `30007`, `30008`, `30009`, `20005`, `20006`, `20007`, `20010`, `20011`, `20012`, `20013`, `20016`, `20019`, `20023`, `20024`, `20025`, `20026`, `20027`, `20028`, `20029`, `20030`, `20031`, `20034`, `20037`, `20038`, `1113`, `1114`, `2106`, `2118` |
+| `EtnicBusinessError` (base / default) | `00025` (security), `00999` (SQL) — left unmapped, not client-fixable |
+
+Numeric ranges (all → `EtnicValidationError`): `4004`-`4012`, `1527`-`1528`, `1598`-`1604`,
+`20015`-`20036`, `30016`-`30017`.
+
+Note: the same code number can mean different things per service (e.g. `20016` in Organisation vs
+the `20015`-`20036` range in Document 2), but they map to the **same class** (`EtnicValidationError`),
+so no service disambiguation is needed.
+
+Suggested implementation:
+
+```python
+_CODE_TO_CLASS: dict[str, Type[EtnicBusinessError]] = {
+    "00009": EtnicNotFoundError,
+    "20102": EtnicDocumentNotAccessibleError,
+    "30003": EtnicDocumentNotAccessibleError,
+    "30006": EtnicDocumentNotAccessibleError,
+    "1530": EtnicAlreadyApprovedError,
+    "1545": EtnicAlreadyApprovedError,
+    "00011": EtnicConcurrencyError,
+    # validation … (all of the above EtnicValidationError codes)
+}
+
+# (low, high, class) — inclusive, matched on int(code) when not in _CODE_TO_CLASS
+_CODE_RANGES: list[tuple[int, int, Type[EtnicBusinessError]]] = [
+    (4004, 4012, EtnicValidationError),
+    (1527, 1528, EtnicValidationError),
+    (1598, 1604, EtnicValidationError),
+    (20015, 20036, EtnicValidationError),
+    (30016, 30017, EtnicValidationError),
+]
+
+
+def map_etnic_error_code_to_class(code):
+    if code is None:
+        return EtnicBusinessError
+    if code in _CODE_TO_CLASS:
+        return _CODE_TO_CLASS[code]
+    try:
+        n = int(code)
+    except (TypeError, ValueError):
+        return EtnicBusinessError
+    for low, high, cls in _CODE_RANGES:
+        if low <= n <= high:
+            return cls
+    return EtnicBusinessError
+```
+
+### 3. Stop masking the real ETNIC message
+
+Goal: `str(exc)` and the auto-built message surface code + ETNIC description.
+- Improve the default message in `signal_business_error` to e.g. `f"ETNIC error {code}: {description}"`.
+- Audit callers that pass a static generic `message=` (e.g. `organisation.py`
+  `"Organisation response was empty or success=False"`). Prefer letting `signal_business_error`
+  build the message from `result`, or pass a **contextual prefix** that does not hide code/description
+  (the `description` attribute must always be populated when ETNIC provided one).
+
+### 4. (Fold-in) Common_v2 `requestId` latent bug
+
+`extract_error_info` reads `header["requestId"]`. The Organisation v7 (Common_v2) response may put
+`requestId`/`transactionId` as **XML attributes**, so `request_id` could always be `None` there.
+Confirm empirically (read the header shape from a real v7 error) and, if so, also read the
+attribute form. If it needs more than a couple of lines, log it as backlog instead of widening 4.2.
+
+### 5. Tests — red→green, one commit per group
+
+For each class, add regression tests asserting the right exception type is raised in strict mode
+for a representative code (use recorded fixtures or the dev server). Suggested commit slicing:
+- `feat(sprint-4): phase 4.2a — add EtnicAlreadyApprovedError + EtnicConcurrencyError`
+- `feat(sprint-4): phase 4.2b — table-driven map_etnic_error_code_to_class (full catalogue)`
+- `fix(sprint-4): phase 4.2c — surface real ETNIC error message (unmask code/description)`
+- (optional) `fix(sprint-4): phase 4.2d — read Common_v2 requestId attribute`
+
+### 6. Empirical confirmation (optional, dev server)
+
+Trigger a few codes live to confirm specs ↔ reality (same discipline that resolved `30004`):
+`30007` (bad anneeScolaire), `20005` (bad numOrganisation), `30003` (status). Assert the mapped
+class and that the description is surfaced.
+
+## Constraints
+
+- **Additive only** — new classes subclass `EtnicBusinessError`; no existing class moved/renamed.
+- **Default mode unchanged** — `RAISE_ON_ERROR == False` still returns `None`.
+- `00025`/`00999` stay on the base class (not client-side validation).
+- Update `docs/PUBLIC_API_SURFACE.md` with the two new exported exception classes.
+
+## Validation
+
+- [ ] `EtnicAlreadyApprovedError` + `EtnicConcurrencyError` added, subclassing `EtnicBusinessError`
+- [ ] `map_etnic_error_code_to_class` table-driven; full catalogue + ranges routed
+- [ ] `30004` now raises `EtnicValidationError`; `str(exc)` contains `30004` + the ETNIC description
+- [ ] Common_v2 `requestId` investigated (fixed or logged as backlog)
+- [ ] Regression tests per group; default mode still returns `None`
+- [ ] `docs/PUBLIC_API_SURFACE.md` updated; suite green

--- a/plan.md
+++ b/plan.md
@@ -316,11 +316,62 @@ Completed on: 2026-06-01
 **Notes for Sprint 4**:
 - Rationalize the `specs/` and `docs/phases/` reference material so it stops inflating the diff
   (decision deferred to post-publication, per the Sprint 3 retro discussion).
-- Two Open questions are unresolved (error-mapping phase scheduling; `typeInterventionExterieure`
-  empirical resolution) — settle their home before locking Sprint 4 scope. See Open questions above.
-- CI has not run on this branch — confirm the 3.10–3.13 matrix is green at push, before merge.
+- Both Open questions resolved in the transition: the `typeInterventionExterieure` Enum fix and the
+  error-code mapping land as Sprint 4 phases 4.1 / 4.2, before the version bump.
+- CI confirmed green on the 3.10–3.13 matrix at push; PR #5 merged to main (merge commit, no squash).
 - Latent-bug backlog (`formations_liste`, `creer/modifier_organisation` None-serialization, `Doc2`
   field order, Common_v2 `requestId`) to triage into Sprint 4 or a 0.1.x backlog.
+
+---
+
+## Sprint 4 — Publication
+
+**Goal**: Make the public contract correct, then ship `0.1.0b1` (beta) to PyPI.
+
+**Branch**: `refactor/sprint-4`
+
+**Scope**: the two correctness fixes surfaced by the 2026-05-31 audit + the 2026-06-01 empirical
+probe (`typeInterventionExterieure` Enum, error-code mapping), then the publication mechanics
+(CHANGELOG, version bump, packaging, PyPI).
+
+**Key design decisions** (Atelier Analyse, Sprint 3 → Sprint 4 transition, 2026-06-01):
+- **Version scheme**: `0.0.12` → `0.1.0b1` (PEP 440 beta), not `0.1.0` + Beta classifier only.
+- **4.2 scope**: wire the full ~60-code catalogue now (red→green), not a minimal subset — the first
+  public release is the right moment to stabilize the exception hierarchy (it is public contract).
+- **PyPI**: TestPyPI dry-run (verify a clean install) before the real PyPI upload — safety net.
+- **Correctness before publication**: 4.1 and 4.2 land before the version bump (4.4).
+
+### Phases
+
+- [ ] **Phase 4.1** — Fix `typeInterventionExterieure` Enum (correctness)
+  - Swap the 13 Enum values from long labels to single-letter codes
+    (A, B, C, D, E, F, I, J, K, P, Q, U, V) per `specs/02_formation_organisation_v7.md`
+    §"Valeurs de typeInterventionExterieure" (validated 2025-06-10)
+  - Fix the falsified `nomenclatures.py` docstring ("these labels are what ETNIC expects verbatim")
+  - Add a regression test pinning the letter values; consider promoting `/tmp/probe_tie.py` into a
+    guarded integration test
+  - Empirical basis: live dev-server probe — `"Convention"` → `30004`, `"C"` accepted (Sprint 3 Findings)
+
+- [ ] **Phase 4.2** — Error-code mapping enrichment (correctness)
+  - Wire the ~60 specs-catalogued codes into `map_etnic_error_code_to_class`
+  - New exception classes: `EtnicValidationError` (30001/30002/30004/30005/30007 + 20xxx, 1113/1114,
+    2106, 4004-4012, 20015-17 …), `EtnicAlreadyApprovedError` (1530/1545),
+    `EtnicConcurrencyError` (00011), `EtnicDocumentNotAccessibleError` (30003/30006)
+  - Surface the real ETNIC message instead of the generic "response was empty or success=False"
+  - Red→green, one commit per code group
+
+- [ ] **Phase 4.3** — CHANGELOG.md (publication)
+  - Create `CHANGELOG.md` (Keep a Changelog format); document the `0.1.0b1` release covering
+    Sprints 0→4, emphasizing public-surface changes (Enum values, exception hierarchy, extras)
+
+- [ ] **Phase 4.4** — Version bump + packaging metadata (publication)
+  - Bump `0.0.12` → `0.1.0b1`; set `Development Status :: 4 - Beta` classifier
+  - Verify `py.typed`, extras `[seps]` / `[excel]`, long_description from README
+  - `python -m build` + `twine check dist/*`
+
+- [ ] **Phase 4.5** — PyPI publication (publication)
+  - Upload to TestPyPI; verify a clean install in a fresh venv (incl. extras)
+  - Upload to PyPI; tag `v0.1.0b1` and push the tag
 
 ---
 
@@ -339,4 +390,5 @@ Completed on: 2026-06-01
 - **[Sprint 3, phase 3.3]** Added `_as_list()` to `_helpers.py`; migrated 11 zeep collection-iteration sites (document1/2/3, formations_liste, seps, inscriptions) and replaced the inline `isinstance(dict)` result guards. Added 5 unit + 4 single-element regression tests (177 → 186). Q8 closed.
 - **[Sprint 3, phase 3.4]** Moved `_ssl_warnings_suppressed` to a `SoapClientManager` class attribute reset by `reset_cache()` (Q5); logged `request_id` on success + rewrote the error log to `%s` (Q6); documented `_EtnicBinarySignature.verify()` (Q3). Added `test_soap_client_unit.py` (190 tests). Q5, Q6, Q3 closed.
 - **[Sprint 3, phase 3.5]** Converted all 20 f-string logger calls to lazy `%s`; guarded the 7 `pformat()` debug calls with `isEnabledFor(DEBUG)`; dropped the unused `pprint` import. Q7 closed — **all 9 Sprint 3 defects addressed** (H2, H5, H8, H11, Q8, Q5, Q6, Q3, Q7). Retrospective + PR/merge pending in the transition conversation.
-- **[Sprint 3, post-merge]** Sprint 3 marked complete (9/9 defects); retrospective filled in. Empirically resolved `typeInterventionExterieure` via a live dev-server write/echo probe — ETNIC wants single-letter codes (`"Convention"` → `30004`, `"C"` accepted); the H9 Enum is wrong. Both the Enum value fix and the error-code mapping enrichment scheduled into Sprint 4 (phases 4.1 / 4.2, before the version bump). 190 tests green.
+- **[Sprint 3, post-merge]** Sprint 3 marked complete (9/9 defects); retrospective filled in. Empirically resolved `typeInterventionExterieure` via a live dev-server write/echo probe — ETNIC wants single-letter codes (`"Convention"` → `30004`, `"C"` accepted); the H9 Enum is wrong. Both the Enum value fix and the error-code mapping enrichment scheduled into Sprint 4 (phases 4.1 / 4.2, before the version bump). 190 tests green. PR #5 merged to main (merge commit `79ddad5`).
+- **[Sprint 4, pre-start]** Sprint 4 section added with phase breakdown (4.1 Enum fix, 4.2 error-code mapping, 4.3 CHANGELOG, 4.4 bump to `0.1.0b1`, 4.5 PyPI). Decisions: `0.1.0b1` (PEP 440 beta), full ~60-code catalogue, TestPyPI dry-run before PyPI.

--- a/plan.md
+++ b/plan.md
@@ -388,10 +388,23 @@ probe (`typeInterventionExterieure` Enum, error-code mapping), then the publicat
   - Adversarially fact-checked every entry against the source (exceptions.py, __init__.py,
     nomenclatures.py, pyproject.toml, _helpers.py, soap_client.py, config.py): all claims confirmed
 
-- [ ] **Phase 4.4** — Version bump + packaging metadata (publication)
-  - Bump `0.0.12` → `0.1.0b1`; set `Development Status :: 4 - Beta` classifier
-  - Verify `py.typed`, extras `[seps]` / `[excel]`, long_description from README
-  - `python -m build` + `twine check dist/*`
+- [x] **Phase 4.4** — Version bump + packaging metadata (publication) _(completed 2026-06-02)_
+  - Bumped `0.0.12` → `0.1.0b1` in **both** `pyproject.toml` and `pyetnic/__init__.py`
+    (dedup to `dynamic = ["version"]` deliberately deferred — "later" per the checklist)
+  - `classifiers`: `Development Status :: 3 - Alpha` → `4 - Beta`
+  - **Decision (asked Fabien): moved `cryptography` from base `dependencies` into `[seps]`**
+    (`["xmlsec", "cryptography"]`) — it is SEPS-only (lazy-imported in `_build_x509_wsse`,
+    guarded by `_x509_available`); lightens the base install, matches CLAUDE.md and the
+    existing X509 error message
+  - Enriched `[project.urls]`: added `Repository`, `Issues`, `Changelog` (only `Homepage` before)
+  - Verified README (484 lines) renders as long_description: no relative/local links, the one
+    image is an absolute GitHub CI badge, `Description-Content-Type: text/markdown`
+  - Built sdist + wheel; `twine check dist/*` → both **PASSED**. Confirmed in the wheel:
+    `py.typed`, 9 WSDL + 73 XSD, no `Codes_Pays.xls`; base deps = zeep/python-dotenv/requests,
+    `[seps]` = xmlsec+cryptography, `[excel]` = openpyxl
+  - **Not** uploaded and **not** merged (TestPyPI/PyPI = 4.5; merge before publishing)
+  - Backlog note: `CHANGELOG.md` is not in the sdist (MANIFEST.in omits it); the Changelog
+    Project-URL covers PyPI discoverability — consider `include CHANGELOG.md` in 4.5
 
 - [ ] **Phase 4.5** — PyPI publication (publication)
   - Upload to TestPyPI; verify a clean install in a fresh venv (incl. extras)
@@ -419,3 +432,4 @@ probe (`typeInterventionExterieure` Enum, error-code mapping), then the publicat
 - **[Sprint 4, phase 4.1]** Corrected `TypeInterventionExterieure` Enum values from long French labels to the single-letter codes ETNIC accepts (A,B,C,D,E,F,I,J,K,P,Q,U,V); member names unchanged, `TYPES_INTERVENTION_EXTERIEURE` auto-derives. Fixed the falsified docstrings, updated 3 unit assertions to `"C"` and added a drift-guard test (190 → 191 green). Optional integration-probe promotion skipped (empirical basis already established).
 - **[Sprint 4, phase 4.2]** Enriched the error-code mapping. Added `EtnicAlreadyApprovedError` (1530/1545) and `EtnicConcurrencyError` (00011); table-driven `map_etnic_error_code_to_class` wires the full `specs/00_REGISTRE.md` §4 catalogue (~60 codes: discrete dict + numeric ranges), routing `EtnicValidationError` (30xxx/20xxx, 1113/1114, 2106/2118, 4004-4012, …) and extending `EtnicDocumentNotAccessibleError` to 30003/30006; 00025/00999 stay on the base class. Unmasked the real ETNIC message (`signal_business_error` auto-builds `"ETNIC error {code}: {description}"`; static `message=` dropped from the 4 parse helpers + `supprimer_organisation`) — `30004` no longer reads "response was empty or success=False". 3 commits (4.2a/b/c), 191 → 230 green, `PUBLIC_API_SURFACE.md` updated. Common_v2 `requestId` attribute (step 4) reasoned-through but left as a 0.1.x backlog item (no live v7 error to confirm the serialized shape).
 - **[Sprint 4, phase 4.3]** Created `CHANGELOG.md` (Keep a Changelog 1.1.0, English, sections Added/Changed/Fixed/Removed/Deprecated) with a single `0.1.0b1` entry spanning the whole `0.0.12` → `0.1.0` delta (Sprints 0→4). Emphasized public-surface changes: `TypeInterventionExterieure` letter codes, enriched exception hierarchy + `EtnicAlreadyApprovedError`/`EtnicConcurrencyError` + ~60-code routing, opt-in strict mode, the 6 `(str, Enum)` nomenclatures, `py.typed`, `[seps]`/`[excel]` extras, deprecated `SoapError` alias + flat namespace. Pre-release install noted (`pip install --pre`); compare links + empty `[Unreleased]` added. Version **not** bumped (phase 4.4); header dated 2026-06-02. Every entry adversarially fact-checked against the source — all claims confirmed.
+- **[Sprint 4, phase 4.4]** Bumped `0.0.12` → `0.1.0b1` in both `pyproject.toml` and `pyetnic/__init__.py` (single-source dedup deferred per checklist); classifier `3 - Alpha` → `4 - Beta`. **Decision (with Fabien): moved `cryptography` from base deps to the `[seps]` extra** (`["xmlsec", "cryptography"]`) since it is SEPS-only (lazy-imported, guarded) — lighter base install. Enriched `[project.urls]` with Repository/Issues/Changelog. Verified README renders as long_description (no local links). Built sdist + wheel; `twine check dist/*` → both PASSED; wheel confirmed to carry `py.typed`, 9 WSDL + 73 XSD, no `Codes_Pays.xls`. No upload, no merge (4.5). Backlog: `CHANGELOG.md` absent from sdist (MANIFEST.in omits it).

--- a/plan.md
+++ b/plan.md
@@ -343,13 +343,17 @@ probe (`typeInterventionExterieure` Enum, error-code mapping), then the publicat
 
 ### Phases
 
-- [ ] **Phase 4.1** — Fix `typeInterventionExterieure` Enum (correctness)
-  - Swap the 13 Enum values from long labels to single-letter codes
+- [x] **Phase 4.1** — Fix `typeInterventionExterieure` Enum (correctness) _(completed 2026-06-01)_
+  - Swapped the 13 Enum values from long labels to single-letter codes
     (A, B, C, D, E, F, I, J, K, P, Q, U, V) per `specs/02_formation_organisation_v7.md`
-    §"Valeurs de typeInterventionExterieure" (validated 2025-06-10)
-  - Fix the falsified `nomenclatures.py` docstring ("these labels are what ETNIC expects verbatim")
-  - Add a regression test pinning the letter values; consider promoting `/tmp/probe_tie.py` into a
-    guarded integration test
+    §"Valeurs de typeInterventionExterieure" (validated 2025-06-10); member names unchanged
+  - Fixed the falsified module + class docstrings (dropped "labels are what ETNIC expects verbatim";
+    documented the removed R/S codes and the legacy-read behaviour)
+  - `TYPES_INTERVENTION_EXTERIEURE` auto-derives the letters (verified, not hand-edited)
+  - Updated 3 `test_nomenclatures.py` assertions to `"C"` (red→green); renamed the now-misleading
+    `test_enum_value_is_verbatim_string`; added a `test_values_are_the_exact_letter_codes` drift guard
+    pinning the full name→letter mapping. 190 → 191 tests green
+  - Integration-probe promotion (optional step 5) skipped — empirical basis already established
   - Empirical basis: live dev-server probe — `"Convention"` → `30004`, `"C"` accepted (Sprint 3 Findings)
 
 - [ ] **Phase 4.2** — Error-code mapping enrichment (correctness)
@@ -392,3 +396,4 @@ probe (`typeInterventionExterieure` Enum, error-code mapping), then the publicat
 - **[Sprint 3, phase 3.5]** Converted all 20 f-string logger calls to lazy `%s`; guarded the 7 `pformat()` debug calls with `isEnabledFor(DEBUG)`; dropped the unused `pprint` import. Q7 closed — **all 9 Sprint 3 defects addressed** (H2, H5, H8, H11, Q8, Q5, Q6, Q3, Q7). Retrospective + PR/merge pending in the transition conversation.
 - **[Sprint 3, post-merge]** Sprint 3 marked complete (9/9 defects); retrospective filled in. Empirically resolved `typeInterventionExterieure` via a live dev-server write/echo probe — ETNIC wants single-letter codes (`"Convention"` → `30004`, `"C"` accepted); the H9 Enum is wrong. Both the Enum value fix and the error-code mapping enrichment scheduled into Sprint 4 (phases 4.1 / 4.2, before the version bump). 190 tests green. PR #5 merged to main (merge commit `79ddad5`).
 - **[Sprint 4, pre-start]** Sprint 4 section added with phase breakdown (4.1 Enum fix, 4.2 error-code mapping, 4.3 CHANGELOG, 4.4 bump to `0.1.0b1`, 4.5 PyPI). Decisions: `0.1.0b1` (PEP 440 beta), full ~60-code catalogue, TestPyPI dry-run before PyPI.
+- **[Sprint 4, phase 4.1]** Corrected `TypeInterventionExterieure` Enum values from long French labels to the single-letter codes ETNIC accepts (A,B,C,D,E,F,I,J,K,P,Q,U,V); member names unchanged, `TYPES_INTERVENTION_EXTERIEURE` auto-derives. Fixed the falsified docstrings, updated 3 unit assertions to `"C"` and added a drift-guard test (190 → 191 green). Optional integration-probe promotion skipped (empirical basis already established).

--- a/plan.md
+++ b/plan.md
@@ -356,13 +356,22 @@ probe (`typeInterventionExterieure` Enum, error-code mapping), then the publicat
   - Integration-probe promotion (optional step 5) skipped — empirical basis already established
   - Empirical basis: live dev-server probe — `"Convention"` → `30004`, `"C"` accepted (Sprint 3 Findings)
 
-- [ ] **Phase 4.2** — Error-code mapping enrichment (correctness)
-  - Wire the ~60 specs-catalogued codes into `map_etnic_error_code_to_class`
-  - New exception classes: `EtnicValidationError` (30001/30002/30004/30005/30007 + 20xxx, 1113/1114,
-    2106, 4004-4012, 20015-17 …), `EtnicAlreadyApprovedError` (1530/1545),
-    `EtnicConcurrencyError` (00011), `EtnicDocumentNotAccessibleError` (30003/30006)
-  - Surface the real ETNIC message instead of the generic "response was empty or success=False"
-  - Red→green, one commit per code group
+- [x] **Phase 4.2** — Error-code mapping enrichment (correctness) _(completed 2026-06-01)_
+  - Added two exception classes (`EtnicAlreadyApprovedError` 1530/1545, `EtnicConcurrencyError` 00011),
+    exported from the top-level + `eprom` namespaces (4.2a)
+  - Replaced the 2-code if-chain with a table-driven `map_etnic_error_code_to_class` wiring the full
+    `specs/00_REGISTRE.md` §4 catalogue: discrete dict + inclusive numeric ranges (4004-4012,
+    1527-1528, 1598-1604, 20015-20036, 30016-30017). `EtnicValidationError` now routed (30001/30002/
+    30004/30005/30007/30008/30009 + 20xxx, 1113/1114, 2106/2118); `EtnicDocumentNotAccessibleError`
+    extended to 30003/30006; 00025 (security) and 00999 (SQL) deliberately left on the base class (4.2b)
+  - Unmasked the real ETNIC message: `signal_business_error` auto-builds `"ETNIC error {code}:
+    {description}"`; the four parse helpers + `supprimer_organisation` dropped their static `message=`.
+    `30004` now reads "ETNIC error 30004: Le type d'intervention extérieure est incorrect" (4.2c)
+  - 191 → 230 tests green; `docs/PUBLIC_API_SURFACE.md` updated with the two new classes
+  - Common_v2 `requestId` (step 4): investigated by reasoning (serialized v7 carries requestId as an
+    XML attribute on the body root, not a SOAP header, so `extract_error_info` likely returns `None`
+    there) but **not empirically confirmed** without a live v7 error response — kept as a 0.1.x backlog
+    item rather than shipping an unverified speculative fix, per the recipe's "log it as backlog" rule
 
 - [ ] **Phase 4.3** — CHANGELOG.md (publication)
   - Create `CHANGELOG.md` (Keep a Changelog format); document the `0.1.0b1` release covering
@@ -397,3 +406,4 @@ probe (`typeInterventionExterieure` Enum, error-code mapping), then the publicat
 - **[Sprint 3, post-merge]** Sprint 3 marked complete (9/9 defects); retrospective filled in. Empirically resolved `typeInterventionExterieure` via a live dev-server write/echo probe — ETNIC wants single-letter codes (`"Convention"` → `30004`, `"C"` accepted); the H9 Enum is wrong. Both the Enum value fix and the error-code mapping enrichment scheduled into Sprint 4 (phases 4.1 / 4.2, before the version bump). 190 tests green. PR #5 merged to main (merge commit `79ddad5`).
 - **[Sprint 4, pre-start]** Sprint 4 section added with phase breakdown (4.1 Enum fix, 4.2 error-code mapping, 4.3 CHANGELOG, 4.4 bump to `0.1.0b1`, 4.5 PyPI). Decisions: `0.1.0b1` (PEP 440 beta), full ~60-code catalogue, TestPyPI dry-run before PyPI.
 - **[Sprint 4, phase 4.1]** Corrected `TypeInterventionExterieure` Enum values from long French labels to the single-letter codes ETNIC accepts (A,B,C,D,E,F,I,J,K,P,Q,U,V); member names unchanged, `TYPES_INTERVENTION_EXTERIEURE` auto-derives. Fixed the falsified docstrings, updated 3 unit assertions to `"C"` and added a drift-guard test (190 → 191 green). Optional integration-probe promotion skipped (empirical basis already established).
+- **[Sprint 4, phase 4.2]** Enriched the error-code mapping. Added `EtnicAlreadyApprovedError` (1530/1545) and `EtnicConcurrencyError` (00011); table-driven `map_etnic_error_code_to_class` wires the full `specs/00_REGISTRE.md` §4 catalogue (~60 codes: discrete dict + numeric ranges), routing `EtnicValidationError` (30xxx/20xxx, 1113/1114, 2106/2118, 4004-4012, …) and extending `EtnicDocumentNotAccessibleError` to 30003/30006; 00025/00999 stay on the base class. Unmasked the real ETNIC message (`signal_business_error` auto-builds `"ETNIC error {code}: {description}"`; static `message=` dropped from the 4 parse helpers + `supprimer_organisation`) — `30004` no longer reads "response was empty or success=False". 3 commits (4.2a/b/c), 191 → 230 green, `PUBLIC_API_SURFACE.md` updated. Common_v2 `requestId` attribute (step 4) reasoned-through but left as a 0.1.x backlog item (no live v7 error to confirm the serialized shape).

--- a/plan.md
+++ b/plan.md
@@ -373,9 +373,20 @@ probe (`typeInterventionExterieure` Enum, error-code mapping), then the publicat
     there) but **not empirically confirmed** without a live v7 error response — kept as a 0.1.x backlog
     item rather than shipping an unverified speculative fix, per the recipe's "log it as backlog" rule
 
-- [ ] **Phase 4.3** — CHANGELOG.md (publication)
-  - Create `CHANGELOG.md` (Keep a Changelog format); document the `0.1.0b1` release covering
-    Sprints 0→4, emphasizing public-surface changes (Enum values, exception hierarchy, extras)
+- [x] **Phase 4.3** — CHANGELOG.md (publication) _(completed 2026-06-02)_
+  - Created `CHANGELOG.md` (Keep a Changelog 1.1.0 format: Added / Changed / Fixed / Removed /
+    Deprecated), in English to match `docs/` and the standard headings; one `0.1.0b1` entry
+    covering the whole `0.0.12` → `0.1.0` delta (Sprints 0→4)
+  - Emphasized the public-surface changes: `TypeInterventionExterieure` letter codes (4.1),
+    enriched exception hierarchy + the two new classes + ~60-code routing (4.2), opt-in strict
+    mode (`strict_errors()` / `RAISE_ON_ERROR`), the 6 `(str, Enum)` nomenclatures, `py.typed`,
+    the `[seps]` / `[excel]` extras, and the deprecated `SoapError` alias + flat namespace
+  - Noted the pre-release install (`pip install --pre pyetnic`); added Keep a Changelog compare
+    links (`v0.0.12...v0.1.0b1`) + an empty `[Unreleased]` section
+  - Did **not** bump the version (that is phase 4.4); the dated `0.1.0b1` header is authored-on
+    today — 4.5 adjusts if the publish slips
+  - Adversarially fact-checked every entry against the source (exceptions.py, __init__.py,
+    nomenclatures.py, pyproject.toml, _helpers.py, soap_client.py, config.py): all claims confirmed
 
 - [ ] **Phase 4.4** — Version bump + packaging metadata (publication)
   - Bump `0.0.12` → `0.1.0b1`; set `Development Status :: 4 - Beta` classifier
@@ -407,3 +418,4 @@ probe (`typeInterventionExterieure` Enum, error-code mapping), then the publicat
 - **[Sprint 4, pre-start]** Sprint 4 section added with phase breakdown (4.1 Enum fix, 4.2 error-code mapping, 4.3 CHANGELOG, 4.4 bump to `0.1.0b1`, 4.5 PyPI). Decisions: `0.1.0b1` (PEP 440 beta), full ~60-code catalogue, TestPyPI dry-run before PyPI.
 - **[Sprint 4, phase 4.1]** Corrected `TypeInterventionExterieure` Enum values from long French labels to the single-letter codes ETNIC accepts (A,B,C,D,E,F,I,J,K,P,Q,U,V); member names unchanged, `TYPES_INTERVENTION_EXTERIEURE` auto-derives. Fixed the falsified docstrings, updated 3 unit assertions to `"C"` and added a drift-guard test (190 → 191 green). Optional integration-probe promotion skipped (empirical basis already established).
 - **[Sprint 4, phase 4.2]** Enriched the error-code mapping. Added `EtnicAlreadyApprovedError` (1530/1545) and `EtnicConcurrencyError` (00011); table-driven `map_etnic_error_code_to_class` wires the full `specs/00_REGISTRE.md` §4 catalogue (~60 codes: discrete dict + numeric ranges), routing `EtnicValidationError` (30xxx/20xxx, 1113/1114, 2106/2118, 4004-4012, …) and extending `EtnicDocumentNotAccessibleError` to 30003/30006; 00025/00999 stay on the base class. Unmasked the real ETNIC message (`signal_business_error` auto-builds `"ETNIC error {code}: {description}"`; static `message=` dropped from the 4 parse helpers + `supprimer_organisation`) — `30004` no longer reads "response was empty or success=False". 3 commits (4.2a/b/c), 191 → 230 green, `PUBLIC_API_SURFACE.md` updated. Common_v2 `requestId` attribute (step 4) reasoned-through but left as a 0.1.x backlog item (no live v7 error to confirm the serialized shape).
+- **[Sprint 4, phase 4.3]** Created `CHANGELOG.md` (Keep a Changelog 1.1.0, English, sections Added/Changed/Fixed/Removed/Deprecated) with a single `0.1.0b1` entry spanning the whole `0.0.12` → `0.1.0` delta (Sprints 0→4). Emphasized public-surface changes: `TypeInterventionExterieure` letter codes, enriched exception hierarchy + `EtnicAlreadyApprovedError`/`EtnicConcurrencyError` + ~60-code routing, opt-in strict mode, the 6 `(str, Enum)` nomenclatures, `py.typed`, `[seps]`/`[excel]` extras, deprecated `SoapError` alias + flat namespace. Pre-release install noted (`pip install --pre`); compare links + empty `[Unreleased]` added. Version **not** bumped (phase 4.4); header dated 2026-06-02. Every entry adversarially fact-checked against the source — all claims confirmed.

--- a/pyetnic/__init__.py
+++ b/pyetnic/__init__.py
@@ -26,7 +26,7 @@ from .exceptions import (
 )
 from .soap_client import SoapError  # legacy alias for EtnicTransportError
 
-__version__ = "0.0.12"
+__version__ = "0.1.0b1"
 __author__ = "Fabien Toune"
 __all__ = [
     "eprom",

--- a/pyetnic/__init__.py
+++ b/pyetnic/__init__.py
@@ -21,6 +21,8 @@ from .exceptions import (
     EtnicDocumentNotAccessibleError,
     EtnicNotFoundError,
     EtnicValidationError,
+    EtnicAlreadyApprovedError,
+    EtnicConcurrencyError,
 )
 from .soap_client import SoapError  # legacy alias for EtnicTransportError
 
@@ -37,6 +39,8 @@ __all__ = [
     "EtnicDocumentNotAccessibleError",
     "EtnicNotFoundError",
     "EtnicValidationError",
+    "EtnicAlreadyApprovedError",
+    "EtnicConcurrencyError",
     "SoapError",
 ]
 

--- a/pyetnic/eprom/__init__.py
+++ b/pyetnic/eprom/__init__.py
@@ -8,6 +8,8 @@ from ..exceptions import (
     EtnicDocumentNotAccessibleError,
     EtnicNotFoundError,
     EtnicValidationError,
+    EtnicAlreadyApprovedError,
+    EtnicConcurrencyError,
 )
 from ..error_mode import strict_errors
 from ..soap_client import SoapError  # legacy alias for EtnicTransportError
@@ -98,6 +100,8 @@ __all__ = [
     "EtnicDocumentNotAccessibleError",
     "EtnicNotFoundError",
     "EtnicValidationError",
+    "EtnicAlreadyApprovedError",
+    "EtnicConcurrencyError",
     "SoapError",
     "strict_errors",
     # Fonctions

--- a/pyetnic/exceptions.py
+++ b/pyetnic/exceptions.py
@@ -130,17 +130,87 @@ class EtnicConcurrencyError(EtnicBusinessError):
 # ---------------------------------------------------------------------------
 
 
+# Discrete ETNIC error codes → exception class. String keys preserve the
+# leading zeros ETNIC uses (e.g. "00009", "00011"). Source: specs/00_REGISTRE.md
+# §4 "Codes d'erreur communs". Codes 00025 (security) and 00999 (internal SQL)
+# are intentionally left on the base class: they are not client-fixable.
+_CODE_TO_CLASS: dict[str, Type[EtnicBusinessError]] = {
+    "00009": EtnicNotFoundError,
+    # Workflow / document not accessible
+    "20102": EtnicDocumentNotAccessibleError,
+    "30003": EtnicDocumentNotAccessibleError,
+    "30006": EtnicDocumentNotAccessibleError,
+    # Already approved by the administration
+    "1530": EtnicAlreadyApprovedError,
+    "1545": EtnicAlreadyApprovedError,
+    # Optimistic-concurrency violation
+    "00011": EtnicConcurrencyError,
+    # Input validation — Organisation (30xxx)
+    "30001": EtnicValidationError,
+    "30002": EtnicValidationError,
+    "30004": EtnicValidationError,
+    "30005": EtnicValidationError,
+    "30007": EtnicValidationError,
+    "30008": EtnicValidationError,
+    "30009": EtnicValidationError,
+    # Input validation — Organisation (20xxx)
+    "20005": EtnicValidationError,
+    "20006": EtnicValidationError,
+    "20007": EtnicValidationError,
+    "20010": EtnicValidationError,
+    "20011": EtnicValidationError,
+    "20012": EtnicValidationError,
+    "20013": EtnicValidationError,
+    "20016": EtnicValidationError,
+    "20019": EtnicValidationError,
+    "20023": EtnicValidationError,
+    "20024": EtnicValidationError,
+    "20025": EtnicValidationError,
+    "20026": EtnicValidationError,
+    "20027": EtnicValidationError,
+    "20028": EtnicValidationError,
+    "20029": EtnicValidationError,
+    "20030": EtnicValidationError,
+    "20031": EtnicValidationError,
+    "20034": EtnicValidationError,
+    "20037": EtnicValidationError,
+    "20038": EtnicValidationError,
+    # Input validation — Documents 1 & 2
+    "1113": EtnicValidationError,
+    "1114": EtnicValidationError,
+    "2106": EtnicValidationError,
+    "2118": EtnicValidationError,
+}
+
+# (low, high, class) — inclusive ranges, matched on int(code) when the code is
+# not in _CODE_TO_CLASS. The same code number can mean different things per
+# service, but every code in these ranges maps to the same class, so no service
+# disambiguation is needed. Source: specs/00_REGISTRE.md §4.
+_CODE_RANGES: list[Tuple[int, int, Type[EtnicBusinessError]]] = [
+    (4004, 4012, EtnicValidationError),   # population consistency (Doc 1)
+    (1527, 1528, EtnicValidationError),   # invalid grouping (Doc 2)
+    (1598, 1604, EtnicValidationError),   # external-intervention type/subtype (Doc 2)
+    (20015, 20036, EtnicValidationError),  # external-intervention errors (Doc 2)
+    (30016, 30017, EtnicValidationError),  # business constraints (Doc 2)
+]
+
+
 def map_etnic_error_code_to_class(code: Optional[str]) -> Type[EtnicBusinessError]:
     """Map a known ETNIC error code to its specialized exception class.
 
-    Returns :class:`EtnicBusinessError` for unknown codes.
+    Returns :class:`EtnicBusinessError` for unknown or not-client-fixable codes.
     """
     if code is None:
         return EtnicBusinessError
-    if code == "20102":
-        return EtnicDocumentNotAccessibleError
-    if code == "00009":
-        return EtnicNotFoundError
+    if code in _CODE_TO_CLASS:
+        return _CODE_TO_CLASS[code]
+    try:
+        n = int(code)
+    except (TypeError, ValueError):
+        return EtnicBusinessError
+    for low, high, cls in _CODE_RANGES:
+        if low <= n <= high:
+            return cls
     return EtnicBusinessError
 
 

--- a/pyetnic/exceptions.py
+++ b/pyetnic/exceptions.py
@@ -304,6 +304,11 @@ def signal_business_error(
 
     cls = error_class or map_etnic_error_code_to_class(code)
     if message is None:
-        message = f"ETNIC business error (code={code}, description={description})"
+        if code is not None:
+            # Surface the real ETNIC code + description instead of a generic
+            # placeholder, so str(exc) is actionable for callers.
+            message = f"ETNIC error {code}: {description}"
+        else:
+            message = "ETNIC business error (empty response or success=False)"
 
     raise cls(message, code=code, description=description, request_id=request_id)

--- a/pyetnic/exceptions.py
+++ b/pyetnic/exceptions.py
@@ -105,6 +105,23 @@ class EtnicValidationError(EtnicBusinessError):
 
     Raised when ETNIC refuses the request for input-validation reasons:
     missing required fields, invalid format, value out of range, etc.
+    Covers the bulk of the ETNIC catalogue (most ``20xxx``/``30xxx`` codes,
+    the population-consistency ``4004``-``4012`` range, etc.).
+    """
+
+
+class EtnicAlreadyApprovedError(EtnicBusinessError):
+    """The document is already approved by the administration.
+
+    Raised when an edit/approve operation targets a document ETNIC has
+    already locked as approved (codes 1530, 1545).
+    """
+
+
+class EtnicConcurrencyError(EtnicBusinessError):
+    """The record was modified by another user since it was read.
+
+    Optimistic-concurrency violation (code 00011) — re-read and retry.
     """
 
 

--- a/pyetnic/nomenclatures.py
+++ b/pyetnic/nomenclatures.py
@@ -11,9 +11,10 @@ Every Enum uses ``(str, Enum)`` so members compare equal to raw strings:
 
 Values for SEPS enums are pinned against the XSD enumerations in
 ``pyetnic/resources/SEPS_Enregistrer_Inscription_2.1/xsd/inscription_v1.xsd``.
-Values for ``TypeInterventionExterieure`` come from the previously
-maintained ``TYPES_INTERVENTION_EXTERIEURE`` constant (the XSD type is a
-free-form ``xs:string``, so these labels are what ETNIC expects verbatim).
+Values for ``TypeInterventionExterieure`` are the single-letter codes from
+the Organisation v7 manual (validated 2025-06-10); the XSD type is a
+free-form ``xs:string`` so they are not contract-validated, but they are the
+values ETNIC actually accepts.
 
 Usage:
     from pyetnic.nomenclatures import TypeInterventionExterieure, CodeSanction
@@ -22,7 +23,7 @@ Usage:
     org.typeInterventionExterieure = TypeInterventionExterieure.CONVENTION.value
 
     # Using the raw string (still works, always will):
-    org.typeInterventionExterieure = "Convention"
+    org.typeInterventionExterieure = "C"
 """
 
 from __future__ import annotations
@@ -34,23 +35,27 @@ class TypeInterventionExterieure(str, Enum):
     """Types d'intervention extérieure pour une organisation.
 
     Used in ``Organisation.typeInterventionExterieure``. The XSD defines
-    the field as ``xs:string`` — these labels are the verbatim values
-    expected by ETNIC.
+    the field as ``xs:string`` — ETNIC expects the single-letter codes
+    below (Organisation v7 manual, validated 2025-06-10), not the long
+    French labels. Codes ``R`` (Récupération périodes) and ``S`` (CISCO
+    Système) were removed by ETNIC and have no member here; reading a
+    legacy organisation that still carries them works (the dataclass keeps
+    the raw string, the Enum simply has no matching member).
     """
 
-    AGENCE_QUALITE = "Agence Qualité"
-    CONVENTION = "Convention"
-    DISCRIMINATIONS_POSITIVES = "Discriminations positives"
-    EHR = "EHR"
-    FONDS_EUROPEENS = "Fonds Européens"
-    FORMATION_PUBLICS_INFRA_SCOLARISES = "Formation des publics infra scolarisés"
-    FORMATIONS_CONTINUEES = "Formations continuées"
-    OCTROI_PERIODES_CABINET_PROJETS_TRANSVER = "Octroi périodes cabinet-projets transver"
-    OCTROI_PERIODES_SUPPLEMENTAIRES_BONUS = "Octroi périodes supplémentaires-bonus"
-    PERSONNEL_NON_CHARGE_DE_COURS = "Personnel non chargé de cours"
-    REORIENTATION_7TQ_7P = "Réorientation 7TQ/7P"
-    UNION_EUROPEENNE = "Union Européenne"
-    VALIDATION_DES_COMPETENCES = "Validation des compétences"
+    AGENCE_QUALITE = "Q"
+    CONVENTION = "C"
+    DISCRIMINATIONS_POSITIVES = "D"
+    EHR = "E"
+    FONDS_EUROPEENS = "F"
+    FORMATION_PUBLICS_INFRA_SCOLARISES = "I"
+    FORMATIONS_CONTINUEES = "P"
+    OCTROI_PERIODES_CABINET_PROJETS_TRANSVER = "K"
+    OCTROI_PERIODES_SUPPLEMENTAIRES_BONUS = "B"
+    PERSONNEL_NON_CHARGE_DE_COURS = "A"
+    REORIENTATION_7TQ_7P = "J"
+    UNION_EUROPEENNE = "U"
+    VALIDATION_DES_COMPETENCES = "V"
 
 
 class CodeAdmission(str, Enum):

--- a/pyetnic/services/document1.py
+++ b/pyetnic/services/document1.py
@@ -35,10 +35,8 @@ class Document1Service:
             and result['body'].get('response')
             and 'document1' in result['body']['response']
         ):
-            return signal_business_error(
-                result,
-                message="Document1 response was empty or success=False",
-            )
+            # Let signal_business_error surface the real ETNIC code + description.
+            return signal_business_error(result)
 
         doc_data = result['body']['response']['document1']
         if logger.isEnabledFor(logging.DEBUG):

--- a/pyetnic/services/document2.py
+++ b/pyetnic/services/document2.py
@@ -38,10 +38,8 @@ class Document2Service:
             and result['body'].get('response')
             and 'document2' in result['body']['response']
         ):
-            return signal_business_error(
-                result,
-                message="Document2 response was empty or success=False",
-            )
+            # Let signal_business_error surface the real ETNIC code + description.
+            return signal_business_error(result)
 
         doc_data = result['body']['response']['document2']
         if logger.isEnabledFor(logging.DEBUG):

--- a/pyetnic/services/document3.py
+++ b/pyetnic/services/document3.py
@@ -35,10 +35,8 @@ class Document3Service:
             and result['body'].get('response')
             and 'document3' in result['body']['response']
         ):
-            return signal_business_error(
-                result,
-                message="Document3 response was empty or success=False",
-            )
+            # Let signal_business_error surface the real ETNIC code + description.
+            return signal_business_error(result)
 
         doc_data = result['body']['response']['document3']
         if logger.isEnabledFor(logging.DEBUG):

--- a/pyetnic/services/organisation.py
+++ b/pyetnic/services/organisation.py
@@ -73,10 +73,9 @@ class OrganisationService:
                 interventionExterieure50p=org_data.get('interventionExterieure50p'),
             )
 
-        return signal_business_error(
-            result,
-            message="Organisation response was empty or success=False",
-        )
+        # No explicit message: let signal_business_error surface the real ETNIC
+        # code + description from `result` instead of masking it.
+        return signal_business_error(result)
 
     # ------------------------------------------------------------------
     # Opérations WSDL
@@ -173,8 +172,5 @@ class OrganisationService:
         )
         success = bool(result and result.get('body', {}).get('success', False))
         if not success:
-            signal_business_error(
-                result,
-                message=f"SupprimerOrganisation failed for {organisation_id}",
-            )
+            signal_business_error(result)
         return success

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pyetnic"
-version = "0.0.12"
+version = "0.1.0b1"
 description = "Access to ETNIC web services through Python"
 readme = "README.md"
 license = "MIT"
@@ -14,10 +14,9 @@ dependencies = [
     "zeep",
     "python-dotenv",
     "requests",
-    "cryptography",
 ]
 classifiers = [
-    "Development Status :: 3 - Alpha",
+    "Development Status :: 4 - Beta",
     "Intended Audience :: Developers",
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3.10",
@@ -29,11 +28,14 @@ classifiers = [
 ]
 
 [project.optional-dependencies]
-seps = ["xmlsec"]
+seps = ["xmlsec", "cryptography"]
 excel = ["openpyxl"]
 
 [project.urls]
 Homepage = "https://github.com/Lapin-Blanc/pyetnic"
+Repository = "https://github.com/Lapin-Blanc/pyetnic"
+Issues = "https://github.com/Lapin-Blanc/pyetnic/issues"
+Changelog = "https://github.com/Lapin-Blanc/pyetnic/blob/main/CHANGELOG.md"
 
 [project.scripts]
 pyetnic = "pyetnic.cli:main"

--- a/tests/regression/test_exceptions.py
+++ b/tests/regression/test_exceptions.py
@@ -7,7 +7,9 @@ They do NOT test that any service actually raises these — that's phase 1.3.
 import pytest
 
 from pyetnic import (
+    EtnicAlreadyApprovedError,
     EtnicBusinessError,
+    EtnicConcurrencyError,
     EtnicDocumentNotAccessibleError,
     EtnicError,
     EtnicNotFoundError,
@@ -44,6 +46,14 @@ def test_not_found_inherits_from_business_error():
 
 def test_validation_inherits_from_business_error():
     assert issubclass(EtnicValidationError, EtnicBusinessError)
+
+
+def test_already_approved_inherits_from_business_error():
+    assert issubclass(EtnicAlreadyApprovedError, EtnicBusinessError)
+
+
+def test_concurrency_inherits_from_business_error():
+    assert issubclass(EtnicConcurrencyError, EtnicBusinessError)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/regression/test_strict_mode.py
+++ b/tests/regression/test_strict_mode.py
@@ -18,9 +18,12 @@ import pytest
 
 from pyetnic import Config, strict_errors
 from pyetnic.eprom import (
+    EtnicAlreadyApprovedError,
     EtnicBusinessError,
+    EtnicConcurrencyError,
     EtnicDocumentNotAccessibleError,
     EtnicNotFoundError,
+    EtnicValidationError,
     OrganisationId,
     SoapError,
     lire_document_1,
@@ -30,6 +33,7 @@ from pyetnic.eprom import (
     lister_formations,
     supprimer_organisation,
 )
+from pyetnic.exceptions import map_etnic_error_code_to_class
 
 
 # ---------------------------------------------------------------------------
@@ -182,6 +186,85 @@ def test_strict_mode_raises_not_found_on_00009(mock_soap_call):
             lire_organisation(SAMPLE_ORG_ID)
 
     assert exc_info.value.code == "00009"
+
+
+# ---------------------------------------------------------------------------
+# Full catalogue routing (map_etnic_error_code_to_class)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "code,expected",
+    [
+        # Discrete codes
+        ("00009", EtnicNotFoundError),
+        ("20102", EtnicDocumentNotAccessibleError),
+        ("30003", EtnicDocumentNotAccessibleError),
+        ("30006", EtnicDocumentNotAccessibleError),
+        ("1530", EtnicAlreadyApprovedError),
+        ("1545", EtnicAlreadyApprovedError),
+        ("00011", EtnicConcurrencyError),
+        ("30001", EtnicValidationError),
+        ("30002", EtnicValidationError),
+        ("30004", EtnicValidationError),  # the 2026-06-01 masked-symptom code
+        ("30005", EtnicValidationError),
+        ("30007", EtnicValidationError),
+        ("30008", EtnicValidationError),
+        ("30009", EtnicValidationError),
+        ("20005", EtnicValidationError),
+        ("20016", EtnicValidationError),
+        ("20038", EtnicValidationError),
+        ("1113", EtnicValidationError),
+        ("1114", EtnicValidationError),
+        ("2106", EtnicValidationError),
+        ("2118", EtnicValidationError),
+        # Numeric ranges
+        ("4004", EtnicValidationError),
+        ("4012", EtnicValidationError),
+        ("1527", EtnicValidationError),
+        ("1600", EtnicValidationError),
+        ("20020", EtnicValidationError),
+        ("30016", EtnicValidationError),
+        ("30017", EtnicValidationError),
+        # Unmapped / not client-fixable → base class
+        ("00025", EtnicBusinessError),
+        ("00999", EtnicBusinessError),
+        ("99999", EtnicBusinessError),
+        (None, EtnicBusinessError),
+    ],
+)
+def test_map_etnic_error_code_to_class(code, expected):
+    assert map_etnic_error_code_to_class(code) is expected
+
+
+def test_map_handles_non_numeric_code():
+    """A non-numeric, unknown code must not raise — falls back to base."""
+    assert map_etnic_error_code_to_class("ABC") is EtnicBusinessError
+
+
+def test_strict_mode_raises_validation_on_30004(mock_soap_call):
+    """ETNIC code 30004 must raise EtnicValidationError, not a generic error."""
+    mock_soap_call.return_value = _error_response(
+        "30004", "Le type d'intervention extérieure est incorrect"
+    )
+    with strict_errors():
+        with pytest.raises(EtnicValidationError) as exc_info:
+            lire_organisation(SAMPLE_ORG_ID)
+    assert exc_info.value.code == "30004"
+
+
+def test_strict_mode_raises_already_approved_on_1530(mock_soap_call):
+    mock_soap_call.return_value = _error_response("1530", "Document déjà approuvé")
+    with strict_errors():
+        with pytest.raises(EtnicAlreadyApprovedError):
+            lire_document_1(SAMPLE_ORG_ID)
+
+
+def test_strict_mode_raises_concurrency_on_00011(mock_soap_call):
+    mock_soap_call.return_value = _error_response("00011", "Modifié par un autre utilisateur")
+    with strict_errors():
+        with pytest.raises(EtnicConcurrencyError):
+            lire_document_2(SAMPLE_ORG_ID)
 
 
 def test_strict_mode_unknown_code_raises_generic_business_error(mock_soap_call):

--- a/tests/regression/test_strict_mode.py
+++ b/tests/regression/test_strict_mode.py
@@ -253,6 +253,24 @@ def test_strict_mode_raises_validation_on_30004(mock_soap_call):
     assert exc_info.value.code == "30004"
 
 
+def test_strict_mode_surfaces_real_etnic_message(mock_soap_call):
+    """str(exc) must carry the real ETNIC code + description, not the generic
+    "response was empty or success=False" placeholder (the 2026-06-01 masking
+    bug)."""
+    mock_soap_call.return_value = _error_response(
+        "30004", "Le type d'intervention extérieure est incorrect"
+    )
+    with strict_errors():
+        with pytest.raises(EtnicValidationError) as exc_info:
+            lire_organisation(SAMPLE_ORG_ID)
+    message = str(exc_info.value)
+    assert "30004" in message
+    assert "Le type d'intervention extérieure est incorrect" in message
+    assert "empty or success=False" not in message
+    # The description attribute must always be populated when ETNIC provided one.
+    assert exc_info.value.description == "Le type d'intervention extérieure est incorrect"
+
+
 def test_strict_mode_raises_already_approved_on_1530(mock_soap_call):
     mock_soap_call.return_value = _error_response("1530", "Document déjà approuvé")
     with strict_errors():

--- a/tests/unit/test_nomenclatures.py
+++ b/tests/unit/test_nomenclatures.py
@@ -15,22 +15,47 @@ from pyetnic.nomenclatures import (
 
 class TestTypeInterventionExterieure:
 
-    def test_enum_value_is_verbatim_string(self):
-        assert TypeInterventionExterieure.CONVENTION.value == "Convention"
-        assert TypeInterventionExterieure.EHR.value == "EHR"
+    def test_enum_value_is_letter_code(self):
+        assert TypeInterventionExterieure.CONVENTION.value == "C"
+        assert TypeInterventionExterieure.EHR.value == "E"
 
     def test_enum_member_is_a_str_subclass(self):
         assert isinstance(TypeInterventionExterieure.CONVENTION, str)
 
     def test_bidirectional_string_comparison(self):
         """(str, Enum) members must compare equal to raw strings both ways."""
-        assert TypeInterventionExterieure.CONVENTION == "Convention"
-        assert "Convention" == TypeInterventionExterieure.CONVENTION
+        assert TypeInterventionExterieure.CONVENTION == "C"
+        assert "C" == TypeInterventionExterieure.CONVENTION
 
     def test_covers_all_legacy_values(self):
-        """Every label in the legacy constant must be representable as an Enum member."""
+        """Every value in the legacy constant must be representable as an Enum member."""
         enum_values = {m.value for m in TypeInterventionExterieure}
         assert set(TYPES_INTERVENTION_EXTERIEURE) == enum_values
+
+    def test_values_are_the_exact_letter_codes(self):
+        """Drift guard: pin the full name->letter mapping so a future edit cannot
+        silently reintroduce the long French labels (which ETNIC rejects, code 30004).
+
+        Authoritative source: specs/02_formation_organisation_v7.md
+        §"Valeurs de typeInterventionExterieure" (validated 2025-06-10).
+        Codes R and S were removed by ETNIC and have no member here.
+        """
+        expected = {
+            "PERSONNEL_NON_CHARGE_DE_COURS": "A",
+            "OCTROI_PERIODES_SUPPLEMENTAIRES_BONUS": "B",
+            "CONVENTION": "C",
+            "DISCRIMINATIONS_POSITIVES": "D",
+            "EHR": "E",
+            "FONDS_EUROPEENS": "F",
+            "FORMATION_PUBLICS_INFRA_SCOLARISES": "I",
+            "REORIENTATION_7TQ_7P": "J",
+            "OCTROI_PERIODES_CABINET_PROJETS_TRANSVER": "K",
+            "FORMATIONS_CONTINUEES": "P",
+            "AGENCE_QUALITE": "Q",
+            "UNION_EUROPEENNE": "U",
+            "VALIDATION_DES_COMPETENCES": "V",
+        }
+        assert {m.name: m.value for m in TypeInterventionExterieure} == expected
 
 
 class TestCodeAdmission:


### PR DESCRIPTION
Sprint 4 — make the public contract correct, then prepare the `0.1.0b1` beta release.

## Correctness (before the version bump)

- **4.1** — `TypeInterventionExterieure` Enum values corrected from long French labels to the single-letter codes ETNIC accepts (`A,B,C,D,E,F,I,J,K,P,Q,U,V`). Empirically validated against the dev server: `"Convention"` → code 30004, `"C"` accepted.
- **4.2** — Error-code mapping enrichment. New `EtnicAlreadyApprovedError` (1530/1545) and `EtnicConcurrencyError` (00011); table-driven `map_etnic_error_code_to_class` wiring the full ~60-code catalogue (discrete table + numeric ranges); business-error messages now surface the real ETNIC code + description instead of a generic placeholder.

## Release prep

- **4.3** — `CHANGELOG.md` (Keep a Changelog), single `0.1.0b1` entry covering the `0.0.12` → `0.1.0` delta (Sprints 0→4).
- **4.4** — Version bump `0.0.12` → `0.1.0b1`; classifier `3 - Alpha` → `4 - Beta`; `cryptography` moved to the `[seps]` extra (SEPS-only, lazy-imported); enriched `[project.urls]` (Repository/Issues/Changelog); `twine check` PASSED on both sdist + wheel.

Tests: 190 → 230 green on the 3.10–3.13 matrix. Publication (tag `v0.1.0b1` → OIDC CI publish) follows in phase 4.5.

🤖 Generated with [Claude Code](https://claude.com/claude-code)