### PR TITLE
fix: SEPS audit follow-up — latent bugs, swallowed errors, inscription nomenclatures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,17 @@ that supports `bN` pre-releases).
 
 ## [Unreleased]
 
+### Added
+
+- **12 SEPS inscription nomenclature enums**, pinned against `inscription_v1.xsd`
+  and exported from `pyetnic.seps`: `CodeStatut`, `Indicateur`, `IndicateurX`,
+  `MotifExemption`, `MotifExemptionSpec`, `TypeEnseignement`, `TitreDelivre`,
+  `Equivalence`, `ValorisationAcquis`, `ValorisationAcquisSanction`,
+  `StatutFinFormation`, `CodeNiveau`.
+- **`SepsSpecificiteSave.regulier1` / `regulier5`** input fields — the inscription
+  input element is typed `SpecificiteDataType` (which carries them), not the dead
+  `SpecificiteDataInputType`.
+
 ### Fixed
 
 - **SEPS responses no longer fail to parse in production.** The SOAP client now
@@ -16,6 +27,22 @@ that supports `bN` pre-releases).
   responses carrying elements absent from the embedded WSDL/XSD (e.g. the SEPS
   inscription `audit` block) are tolerated instead of raising `XMLParseError`.
   Applies to all services (EPROM and SEPS).
+- **SEPS student services no longer swallow server errors as `None`.**
+  `lire_etudiant`, `enregistrer_etudiant` and `modifier_etudiant` now inspect the
+  response block and raise the typed SEPS exceptions (e.g. `SepsAuthError`,
+  `SepsEtnicError`) instead of returning `None`. "Not found" codes (30110/30115)
+  still yield `None`/`[]`.
+- **A single `autrePrenom` is no longer split into characters** — `_as_list`
+  treats `str`/`bytes` as a scalar element.
+- **`creer_organisation` / `modifier_organisation` no longer serialize `None`
+  fields** as empty XML elements (which ETNIC reads as "erase"); they are stripped
+  like the document services.
+- **`FormationsListeResult.messages` is now a flat `List[str]`** on error, instead
+  of leaking the raw SOAP `messagesType` dict.
+- **`Doc2ActiviteEnseignementLine` field order realigned to the XSD** (`coEtuReg`
+  last; the four regroupement fields are required, no misleading `=0` defaults).
+- **`extract_error_info` resolves `requestId` from the Common_v2 body attribute**
+  (Organisation v7) when no SOAP header value is present.
 
 ## [0.1.0b1] - 2026-06-02
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,14 @@ that supports `bN` pre-releases).
 
 ## [Unreleased]
 
+### Fixed
+
+- **SEPS responses no longer fail to parse in production.** The SOAP client now
+  builds its `zeep` client with `Settings(strict=False)`, so ETNIC production
+  responses carrying elements absent from the embedded WSDL/XSD (e.g. the SEPS
+  inscription `audit` block) are tolerated instead of raising `XMLParseError`.
+  Applies to all services (EPROM and SEPS).
+
 ## [0.1.0b1] - 2026-06-02
 
 First public **beta** of the refactored library. This entry covers the whole

--- a/docs/PUBLIC_API_SURFACE.md
+++ b/docs/PUBLIC_API_SURFACE.md
@@ -92,6 +92,20 @@ All use `(str, Enum)` base — members compare equal to their raw string value.
 | `MotifAbandon` | Abandon reasons. Exported from `pyetnic.eprom` and `pyetnic.seps`. |
 | `DureeInoccupation` | Inoccupation duration codes. Exported from `pyetnic.eprom` and `pyetnic.seps`. |
 | `SituationMenage` | Household situation codes. Exported from `pyetnic.eprom` and `pyetnic.seps`. |
+| `CodeStatut` | Inscription status (DE/AN). Exported from `pyetnic.seps`. |
+| `Indicateur` | Boolean indicator (O/N). Exported from `pyetnic.seps`. |
+| `IndicateurX` | Ternary indicator (O/N/X). Exported from `pyetnic.seps`. |
+| `MotifExemption` | DI exemption reasons (C01-C07). Exported from `pyetnic.seps`. |
+| `MotifExemptionSpec` | DIS exemption reasons (C01-C13, non-EEC). Exported from `pyetnic.seps`. |
+| `TypeEnseignement` | Education type (9 codes). Exported from `pyetnic.seps`. |
+| `TitreDelivre` | Delivered titles (23 codes). Exported from `pyetnic.seps`. |
+| `Equivalence` | Foreign-title equivalence (C01-C04). Exported from `pyetnic.seps`. |
+| `ValorisationAcquis` | Prior-learning valorisation at admission. Exported from `pyetnic.seps`. |
+| `ValorisationAcquisSanction` | Prior-learning valorisation at sanction. Exported from `pyetnic.seps`. |
+| `StatutFinFormation` | End-of-training status (C01-C06, FSE). Exported from `pyetnic.seps`. |
+| `CodeNiveau` | UE level code (SI/SS/SC/SL). Exported from `pyetnic.seps`. |
+
+All SEPS inscription enums are pinned against `inscription_v1.xsd`.
 
 ### Stable — Exceptions
 

--- a/examples/audit_coherence_doc1_seps.py
+++ b/examples/audit_coherence_doc1_seps.py
@@ -10,8 +10,17 @@ nominative student data (no NISS, name, address...).
 
 Strategy:
 - one bulk SEPS call retrieves every inscription, grouped by (numAdm, numOrg);
+  inscriptions whose status is excluded (cancelled, ``AN``) are dropped;
 - the Doc 1 is read per organisation, but only for organisations whose
   population/periods document is approved (otherwise Doc 1 is not accessible).
+
+Discrepancy kinds:
+- ``MISMATCH``           — approved org, both sides > 0 but differ;
+- ``DECLARED_NO_SEPS``   — approved org declares a population, SEPS has none;
+- ``SEPS_NO_DECLARED``   — approved org declares 0, SEPS has inscriptions;
+- ``NOT_APPROVED``       — org not approved yet (Doc 1 unreadable) but SEPS has
+                           inscriptions: the real org status is shown;
+- ``ORPHAN_SEPS``        — SEPS inscriptions for an org absent from EPROM.
 
 Usage:
     python examples/audit_coherence_doc1_seps.py --annee 2025-2026 --etab 3052
@@ -28,10 +37,14 @@ from dataclasses import dataclass
 import pyetnic.eprom as eprom
 import pyetnic.seps as seps
 
-# Discrepancy kinds
-MISMATCH = "MISMATCH"  # both sides > 0 but differ
-DECLARED_NO_SEPS = "DECLARED_NO_SEPS"  # Doc 1 declares a population, SEPS has none
-SEPS_NO_DECLARED = "SEPS_NO_DECLARED"  # SEPS has inscriptions, Doc 1 declares none / not approved
+MISMATCH = "MISMATCH"
+DECLARED_NO_SEPS = "DECLARED_NO_SEPS"
+SEPS_NO_DECLARED = "SEPS_NO_DECLARED"
+NOT_APPROVED = "NOT_APPROVED"
+ORPHAN_SEPS = "ORPHAN_SEPS"
+
+# SEPS inscription statuses dropped by default: ``AN`` = annulé (cancelled).
+DEFAULT_EXCLUDED_STATUSES: tuple[str, ...] = ("AN",)
 
 
 @dataclass
@@ -45,10 +58,22 @@ class Discrepancy:
     doc1: int
     seps: int
     kind: str
+    org_status: str
 
     @property
     def delta(self) -> int:
         return self.seps - self.doc1
+
+
+@dataclass
+class AuditResult:
+    """Outcome of an audit run, including transparency counters."""
+
+    discrepancies: list[Discrepancy]
+    organisations_scanned: int
+    seps_total: int
+    seps_excluded: int
+    excluded_statuses: tuple[str, ...]
 
 
 def _doc1_headcount(org_id: object) -> int | None:
@@ -70,13 +95,25 @@ def _doc1_headcount(org_id: object) -> int | None:
     )
 
 
-def audit(annee_scolaire: str, etab_id: int) -> list[Discrepancy]:
-    """Return the list of organisations where Doc 1 and SEPS head-counts differ."""
+def audit(
+    annee_scolaire: str,
+    etab_id: int,
+    excluded_statuses: tuple[str, ...] = DEFAULT_EXCLUDED_STATUSES,
+) -> AuditResult:
+    """Return the organisations where Doc 1 and SEPS head-counts differ."""
     year_int = int(annee_scolaire.split("-")[0])
+    excluded = set(excluded_statuses)
 
-    # 1) Every SEPS inscription in a single call, grouped by (numAdm, numOrg).
+    # 1) Every SEPS inscription in a single call, grouped by (numAdm, numOrg),
+    #    dropping excluded (e.g. cancelled) statuses.
     seps_by_org: Counter[tuple[int, int]] = Counter()
+    seps_total = 0
+    seps_excluded = 0
     for ins in seps.rechercher_inscriptions(annee_scolaire=year_int, etab_id=etab_id):
+        seps_total += 1
+        if ins.statut in excluded:
+            seps_excluded += 1
+            continue
         if ins.ue:
             seps_by_org[(ins.ue.noAdministratif, ins.ue.noOrganisation)] += 1
 
@@ -84,22 +121,25 @@ def audit(annee_scolaire: str, etab_id: int) -> list[Discrepancy]:
     res = eprom.lister_formations(annee_scolaire=annee_scolaire)
     discrepancies: list[Discrepancy] = []
     accounted: set[tuple[int, int]] = set()
+    scanned = 0
 
     for formation in res.formations:
         for org in formation.organisations:
+            scanned += 1
             key = (formation.numAdmFormation, org.id.numOrganisation)
             seps_n = seps_by_org.get(key, 0)
             status = org.statutDocumentPopulationPeriodes
+            status_label = status.statut if status else "—"
             approved = bool(status and status.statut == "Approuvé")
 
             if not approved:
-                # Doc 1 is not accessible; only worth flagging if SEPS has inscriptions
-                # (EPROM encoding lagging behind real registrations).
+                # Doc 1 not accessible; flag only if SEPS already has inscriptions
+                # (real registrations preceding EPROM approval).
                 if seps_n:
                     accounted.add(key)
                     discrepancies.append(
                         Discrepancy(key[0], key[1], formation.codeFormation,
-                                    formation.libelleFormation, 0, seps_n, SEPS_NO_DECLARED)
+                                    formation.libelleFormation, 0, seps_n, NOT_APPROVED, status_label)
                     )
                 continue
 
@@ -115,7 +155,7 @@ def audit(annee_scolaire: str, etab_id: int) -> list[Discrepancy]:
                 kind = MISMATCH
             discrepancies.append(
                 Discrepancy(key[0], key[1], formation.codeFormation,
-                            formation.libelleFormation, doc1_n, seps_n, kind)
+                            formation.libelleFormation, doc1_n, seps_n, kind, status_label)
             )
 
     # 3) SEPS inscriptions pointing at an organisation absent from the EPROM catalogue.
@@ -123,9 +163,10 @@ def audit(annee_scolaire: str, etab_id: int) -> list[Discrepancy]:
         if key not in accounted:
             discrepancies.append(
                 Discrepancy(key[0], key[1], "?",
-                            "(organisation absente du catalogue EPROM)", 0, seps_n, SEPS_NO_DECLARED)
+                            "(organisation absente du catalogue EPROM)", 0, seps_n, ORPHAN_SEPS, "—")
             )
-    return discrepancies
+
+    return AuditResult(discrepancies, scanned, seps_total, seps_excluded, tuple(excluded_statuses))
 
 
 def main() -> None:
@@ -134,20 +175,36 @@ def main() -> None:
     )
     parser.add_argument("--annee", default="2025-2026", help="School year, e.g. 2025-2026")
     parser.add_argument("--etab", type=int, default=3052, help="Établissement id")
+    parser.add_argument(
+        "--exclure-statuts", nargs="*", metavar="STATUT",
+        default=list(DEFAULT_EXCLUDED_STATUSES),
+        help="SEPS inscription statuses to ignore (default: AN = cancelled). "
+             "Pass with no value to count every status.",
+    )
     args = parser.parse_args()
 
-    discrepancies = audit(args.annee, args.etab)
+    result = audit(args.annee, args.etab, tuple(args.exclure_statuts))
     header = f"[{args.annee} / etab {args.etab}]"
-    if not discrepancies:
-        print(f"{header} Aucune incohérence Doc 1 <-> SEPS. OK")
+    excl_codes = ",".join(result.excluded_statuses) or "—"
+    seps_line = (f"  SEPS : {result.seps_total} inscriptions, "
+                 f"{result.seps_excluded} exclue(s) [{excl_codes}].")
+
+    if not result.discrepancies:
+        print(f"{header} Aucune incohérence Doc 1 <-> SEPS sur "
+              f"{result.organisations_scanned} organisations. OK")
+        print(seps_line)
         return
 
-    by_kind = Counter(d.kind for d in discrepancies)
-    print(f"{header} {len(discrepancies)} incohérence(s) Doc 1 <-> SEPS : {dict(by_kind)}\n")
-    print(f"  {'UE/org':<12}{'Doc1':>6}{'SEPS':>6}{'delta':>7}  {'type':<17}libellé")
-    for d in sorted(discrepancies, key=lambda x: (x.kind, -abs(x.delta))):
+    by_kind = Counter(d.kind for d in result.discrepancies)
+    print(f"{header} {len(result.discrepancies)} incohérence(s) / "
+          f"{result.organisations_scanned} org. : {dict(by_kind)}")
+    print(seps_line + "\n")
+    print(f"  {'UE/org':<12}{'Doc1':>5}{'SEPS':>5}{'delta':>7}  "
+          f"{'type':<17}{'statut org':<15}libellé")
+    for d in sorted(result.discrepancies, key=lambda x: (x.kind, -abs(x.delta))):
         ue_org = f"{d.num_adm}/{d.num_org}"
-        print(f"  {ue_org:<12}{d.doc1:>6}{d.seps:>6}{d.delta:>+7}  {d.kind:<17}{d.label[:38]}")
+        print(f"  {ue_org:<12}{d.doc1:>5}{d.seps:>5}{d.delta:>+7}  "
+              f"{d.kind:<17}{d.org_status:<15}{d.label[:32]}")
 
 
 if __name__ == "__main__":

--- a/examples/audit_coherence_doc1_seps.py
+++ b/examples/audit_coherence_doc1_seps.py
@@ -1,0 +1,154 @@
+"""Audit: cross-check declared EPROM Doc 1 population against real SEPS inscriptions.
+
+For a given établissement and school year, compare — per organisation — the
+headcount declared in the EPROM Document 1 (population, which drives funding)
+with the number of real inscriptions recorded in SEPS. Only discrepancies are
+reported.
+
+Aggregate-only: this tool manipulates and prints **counters only**, never any
+nominative student data (no NISS, name, address...).
+
+Strategy:
+- one bulk SEPS call retrieves every inscription, grouped by (numAdm, numOrg);
+- the Doc 1 is read per organisation, but only for organisations whose
+  population/periods document is approved (otherwise Doc 1 is not accessible).
+
+Usage:
+    python examples/audit_coherence_doc1_seps.py --annee 2025-2026 --etab 3052
+
+Requires a production-configured ``.env`` (EPROM credentials + SEPS X509 PFX).
+"""
+
+from __future__ import annotations
+
+import argparse
+from collections import Counter
+from dataclasses import dataclass
+
+import pyetnic.eprom as eprom
+import pyetnic.seps as seps
+
+# Discrepancy kinds
+MISMATCH = "MISMATCH"  # both sides > 0 but differ
+DECLARED_NO_SEPS = "DECLARED_NO_SEPS"  # Doc 1 declares a population, SEPS has none
+SEPS_NO_DECLARED = "SEPS_NO_DECLARED"  # SEPS has inscriptions, Doc 1 declares none / not approved
+
+
+@dataclass
+class Discrepancy:
+    """A single organisation where Doc 1 and SEPS head-counts disagree."""
+
+    num_adm: int
+    num_org: int
+    code: str
+    label: str
+    doc1: int
+    seps: int
+    kind: str
+
+    @property
+    def delta(self) -> int:
+        return self.seps - self.doc1
+
+
+def _doc1_headcount(org_id: object) -> int | None:
+    """Total declared head-count (H+F summed over every study-year line).
+
+    Returns ``None`` when the document cannot be read despite an approved status
+    (the organisation is then skipped rather than reported as a false 0).
+    """
+    try:
+        with eprom.strict_errors():
+            doc1 = eprom.lire_document_1(org_id)
+    except eprom.EtnicError:
+        return None
+    if not doc1 or not doc1.populationListe or not doc1.populationListe.population:
+        return 0
+    return sum(
+        (line.nbEleveTotHom or 0) + (line.nbEleveTotFem or 0)
+        for line in doc1.populationListe.population
+    )
+
+
+def audit(annee_scolaire: str, etab_id: int) -> list[Discrepancy]:
+    """Return the list of organisations where Doc 1 and SEPS head-counts differ."""
+    year_int = int(annee_scolaire.split("-")[0])
+
+    # 1) Every SEPS inscription in a single call, grouped by (numAdm, numOrg).
+    seps_by_org: Counter[tuple[int, int]] = Counter()
+    for ins in seps.rechercher_inscriptions(annee_scolaire=year_int, etab_id=etab_id):
+        if ins.ue:
+            seps_by_org[(ins.ue.noAdministratif, ins.ue.noOrganisation)] += 1
+
+    # 2) EPROM organisations for the year.
+    res = eprom.lister_formations(annee_scolaire=annee_scolaire)
+    discrepancies: list[Discrepancy] = []
+    accounted: set[tuple[int, int]] = set()
+
+    for formation in res.formations:
+        for org in formation.organisations:
+            key = (formation.numAdmFormation, org.id.numOrganisation)
+            seps_n = seps_by_org.get(key, 0)
+            status = org.statutDocumentPopulationPeriodes
+            approved = bool(status and status.statut == "Approuvé")
+
+            if not approved:
+                # Doc 1 is not accessible; only worth flagging if SEPS has inscriptions
+                # (EPROM encoding lagging behind real registrations).
+                if seps_n:
+                    accounted.add(key)
+                    discrepancies.append(
+                        Discrepancy(key[0], key[1], formation.codeFormation,
+                                    formation.libelleFormation, 0, seps_n, SEPS_NO_DECLARED)
+                    )
+                continue
+
+            accounted.add(key)
+            doc1_n = _doc1_headcount(org.id)
+            if doc1_n is None or doc1_n == seps_n:
+                continue
+            if seps_n == 0:
+                kind = DECLARED_NO_SEPS
+            elif doc1_n == 0:
+                kind = SEPS_NO_DECLARED
+            else:
+                kind = MISMATCH
+            discrepancies.append(
+                Discrepancy(key[0], key[1], formation.codeFormation,
+                            formation.libelleFormation, doc1_n, seps_n, kind)
+            )
+
+    # 3) SEPS inscriptions pointing at an organisation absent from the EPROM catalogue.
+    for key, seps_n in seps_by_org.items():
+        if key not in accounted:
+            discrepancies.append(
+                Discrepancy(key[0], key[1], "?",
+                            "(organisation absente du catalogue EPROM)", 0, seps_n, SEPS_NO_DECLARED)
+            )
+    return discrepancies
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Cross-check EPROM Doc 1 population vs SEPS inscriptions (discrepancies only)."
+    )
+    parser.add_argument("--annee", default="2025-2026", help="School year, e.g. 2025-2026")
+    parser.add_argument("--etab", type=int, default=3052, help="Établissement id")
+    args = parser.parse_args()
+
+    discrepancies = audit(args.annee, args.etab)
+    header = f"[{args.annee} / etab {args.etab}]"
+    if not discrepancies:
+        print(f"{header} Aucune incohérence Doc 1 <-> SEPS. OK")
+        return
+
+    by_kind = Counter(d.kind for d in discrepancies)
+    print(f"{header} {len(discrepancies)} incohérence(s) Doc 1 <-> SEPS : {dict(by_kind)}\n")
+    print(f"  {'UE/org':<12}{'Doc1':>6}{'SEPS':>6}{'delta':>7}  {'type':<17}libellé")
+    for d in sorted(discrepancies, key=lambda x: (x.kind, -abs(x.delta))):
+        ue_org = f"{d.num_adm}/{d.num_org}"
+        print(f"  {ue_org:<12}{d.doc1:>6}{d.seps:>6}{d.delta:>+7}  {d.kind:<17}{d.label[:38]}")
+
+
+if __name__ == "__main__":
+    main()

--- a/plan.md
+++ b/plan.md
@@ -468,8 +468,11 @@ Completed on: 2026-06-02 — **`0.1.0b1` published to PyPI.**
 - ~~Rationalize `specs/` and `docs/phases/` so they stop inflating the diff ~6×.~~
   **Done (2026-06-02, post-publication housekeeping):** `docs/phases/` deleted (Track A scaffolding,
   consumed); `specs/` kept and enriched to 6/6 services (Track B, live). See the changelog entry below.
-- Four latent bugs: `formations_liste` dict-where-`List[str]`; `creer/modifier_organisation`
-  `None`-serialization; `Doc2` read-field order vs XSD; Common_v2 `requestId` as an XML attribute.
+- ~~Four latent bugs: `formations_liste` dict-where-`List[str]`; `creer/modifier_organisation`
+  `None`-serialization; `Doc2` read-field order vs XSD; Common_v2 `requestId` as an XML attribute.~~
+  **All four fixed (2026-06-10)** on branch `fix/seps-latent-bugs-and-org-none` — see the
+  post-publication maintenance entry below. The Common_v2 `requestId` fix is a non-regressive
+  `body['requestId']` fallback, still unconfirmed against a live v7 error response.
 - Dedup the version to a single source (`dynamic = ["version"]`).
 - Bump the deprecated Node 20 GitHub Actions; consider `include CHANGELOG.md` in MANIFEST.in.
 - Default-mode flip to "raise" + `0.1.0` final / `0.2.0` planning.
@@ -499,4 +502,23 @@ Completed on: 2026-06-02 — **`0.1.0b1` published to PyPI.**
 - **[Sprint 4, phase 4.4]** Bumped `0.0.12` → `0.1.0b1` in both `pyproject.toml` and `pyetnic/__init__.py` (single-source dedup deferred per checklist); classifier `3 - Alpha` → `4 - Beta`. **Decision (with Fabien): moved `cryptography` from base deps to the `[seps]` extra** (`["xmlsec", "cryptography"]`) since it is SEPS-only (lazy-imported, guarded) — lighter base install. Enriched `[project.urls]` with Repository/Issues/Changelog. Verified README renders as long_description (no local links). Built sdist + wheel; `twine check dist/*` → both PASSED; wheel confirmed to carry `py.typed`, 9 WSDL + 73 XSD, no `Codes_Pays.xls`. No upload, no merge (4.5). Backlog: `CHANGELOG.md` absent from sdist (MANIFEST.in omits it).
 - **[Sprint 4, phase 4.5]** **Published `0.1.0b1` to PyPI.** Decided (asked Fabien) _not_ to add `CHANGELOG.md` to the sdist (kept as backlog). Merged `refactor/sprint-4` → `main` via PR #6 (merge commit `ccdb8a9`, no squash; `tests.yml` green on `pull_request`). Clean build from `main`; `twine check` PASSED (sdist + wheel). Local install rehearsal (no upload): wheel + sdist with `[seps]` in fresh venvs — `xmlsec` resolved as a prebuilt cp313 wheel, `import pyetnic` → `0.1.0b1`, `CONVENTION == "C"`, CLI OK. Pushed annotated tag `v0.1.0b1` on `ccdb8a9` → `publish-pypi.yml` published to prod PyPI via OIDC Trusted Publishing (run `26810820326`, 37 s green, no token). Post-check: `pip install --pre pyetnic` → `0.1.0b1` (base install pulls neither `xmlsec` nor `cryptography`); project page HTTP 200.
 - **[Sprint 4, post-publication]** Sprint 4 marked complete (Global progress); phase 4.5 detailed; Sprint 4 retrospective drafted (subjective sections pending Fabien). Backlog carried forward: rationalize `specs/`/`docs/phases/`, the four latent bugs, version single-source, Node 20 action bump, `CHANGELOG.md` in MANIFEST.in.
+- **[2026-06-10, post-publication maintenance — specs↔code audit follow-up]** A multi-agent
+  audit confronting the session-7 enriched `specs/` (full SEPS family + circulaires + INS
+  referentials) against the code drove a round of correctness fixes on branch
+  `fix/seps-latent-bugs-and-org-none` (not yet merged). **SEPS quick-wins:** `lire_etudiant` /
+  `enregistrer_etudiant` / `modifier_etudiant` no longer swallow business errors as `None`
+  (shared `_check_seps_errors` raises typed exceptions; NOT_FOUND 30110/30115 still yield None/[]);
+  `_as_list` hardened to treat `str`/`bytes` as scalar, fixing `autrePrenom` char-splitting.
+  **Four known latent bugs closed:** organisation `None`-serialization (`_strip_none_recursive` on
+  creer/modifier), `formations_liste` messagesType→`List[str]` (`_flatten_messages`),
+  `Doc2ActiviteEnseignementLine` field order realigned to the XSD (coEtuReg last, no `=0`
+  defaults), and a non-regressive `body['requestId']` fallback in `extract_error_info` for
+  Common_v2 (still unconfirmed against a live v7 error). **Nomenclatures (option 2):** added the 12
+  missing inscription enums (CodeStatut, Indicateur, IndicateurX, MotifExemption,
+  MotifExemptionSpec, TypeEnseignement, TitreDelivre×23, Equivalence, ValorisationAcquis,
+  ValorisationAcquisSanction, StatutFinFormation, CodeNiveau) pinned against `inscription_v1.xsd`
+  and exported from `pyetnic.seps`; fixed `SepsSpecificiteSave` (added regulier1/regulier5 — the
+  input element is `SpecificiteDataType`, not the dead `SpecificiteDataInputType`). 254→283 tests
+  green. Remaining audit backlog (not done): SEPS Notifications + Document 1D services, SEPS error
+  codes in the typed hierarchy, INS referential wiring, `Sexe`/`ModeEnregistrement` enums.
 - **[2026-06-02, post-publication housekeeping]** Rationalized the reference material now that Track A is closed (with Fabien). Committed the Track B analysis sessions 4–5 (`specs/05_document3_v1.md`, `specs/06_formation_droits_inscription_v1.md`; enriched `00_REGISTRE`/`00_SUIVI_SESSIONS` with the Doc3/Doc1D types) — Track B now **6/6 EPROM services**. Deleted `docs/phases/` (30 consumed phase-prompt files; recoverable via git history). Rewrote `docs/SOURCES.md` (Track A complete / Track B live), removed the `docs/phases/` convention from `docs/BACKWARDS_COMPAT.md` and the pointer from `CLAUDE.md`, and refreshed this file's stale header (was "Sprint 3 / `refactor/sprint-3`"). Neither `specs/` nor `docs/phases/` is packaged (MANIFEST.in), so zero impact on the published `0.1.0b1` artifact.

--- a/pyetnic/exceptions.py
+++ b/pyetnic/exceptions.py
@@ -237,6 +237,15 @@ def extract_error_info(result: Any) -> Tuple[Optional[str], Optional[str], Optio
     if not isinstance(body, dict):
         return code, description, request_id
 
+    # Common_v2 services (e.g. Organisation v7) carry requestId as an XML
+    # attribute on the response body root rather than in a SOAP header, so it
+    # lands as a top-level key of ``body`` after zeep serialization. Fall back
+    # to it when no header requestId was found (non-regressive for v1/v3).
+    if request_id is None:
+        rid = body.get("requestId")
+        if rid is not None:
+            request_id = str(rid)
+
     messages = body.get("messages") or {}
     if not isinstance(messages, dict):
         return code, description, request_id

--- a/pyetnic/nomenclatures.py
+++ b/pyetnic/nomenclatures.py
@@ -128,6 +128,241 @@ class SituationMenage(str, Enum):
     INCONNU = "X"
 
 
+class CodeStatut(str, Enum):
+    """Statut d'une inscription (CodeStatutType).
+
+    Used in ``Inscription.statut`` / ``InscriptionInputSave.statut``.
+    Values pinned against XSD ``CodeStatutType``.
+    """
+
+    DEFINITIVE = "DE"
+    ANNULEE = "AN"
+
+
+class Indicateur(str, Enum):
+    """Indicateur booléen ETNIC (IndicateurType) : oui / non.
+
+    Pilote les nombreux champs ``"O"`` / ``"N"`` du contrat inscription
+    (``regulier1`` / ``regulier5``, ``enfantACharge``, ``fse``, les
+    indicateurs DI/DIS…). Values pinned against XSD ``IndicateurType``.
+    """
+
+    OUI = "O"
+    NON = "N"
+
+
+class IndicateurX(str, Enum):
+    """Indicateur ternaire (IndicateurXType) : oui / non / n'accepte pas de préciser.
+
+    Distinct de :class:`Indicateur` (qui n'accepte pas ``"X"``). Utilisé par
+    ``SepsSpecificite.difficulteHandicap`` et ``difficulteAutre``. Values
+    pinned against XSD ``IndicateurXType``.
+    """
+
+    OUI = "O"
+    NON = "N"
+    NON_PRECISE = "X"
+
+
+class MotifExemption(str, Enum):
+    """Motif d'exemption du droit d'inscription (MotifExemptionType, DI).
+
+    Used in ``SepsExempteDroitInscription.motifExemption``. Libellés : cf.
+    circulaire 9593 (spec 14). Values pinned against XSD ``MotifExemptionType``.
+    """
+
+    MINEUR = "C01"                  # Mineur soumis à l'obligation scolaire
+    CHOMEUR_INDEMNISE = "C02"       # Chômeur complet indemnisé
+    HANDICAP = "C03"                # Étudiant avec handicap reconnu
+    RIS = "C04"                     # Bénéficiaire du revenu d'intégration (RIS)
+    PERSONNEL_ENSEIGNANT = "C05"    # Personnel enseignant en formation continuée
+    AUTORITE_PUBLIQUE = "C06"       # Obligation d'une autorité publique
+    AUTRE = "C07"                   # Autre
+
+
+class MotifExemptionSpec(str, Enum):
+    """Motif d'exemption du droit d'inscription spécifique (MotifExemptionSpecType, DIS).
+
+    Réservé aux étudiants de nationalité hors CEE (sinon erreur 30023).
+    Used in ``SepsExempteDroitInscriptionSpec.motifExemptionSpec``. Members are
+    the raw codes; the 13 motifs (manuel §3.1.11) are:
+
+    - C01 Soumis à l'obligation scolaire
+    - C02 Ressortissant d'un État membre UE
+    - C03 Parents/tuteur belges
+    - C04 Parents/tuteur (non belges) résidant en Belgique
+    - C05 Marié/cohabitant avec conjoint résidant en Belgique
+    - C06 Résidant en Belgique avec activité prof. ou revenu de remplacement
+    - C07 Réfugié ou candidat réfugié reconnu
+    - C08 Pris en charge par le CPAS
+    - C09 Admis à séjourner > 3 mois (loi 15/12/1980)
+    - C10 Demande de régularisation (loi 15/12/1980)
+    - C11 Placé par le juge de la jeunesse
+    - C12 Sous tutelle officieuse (Code civil)
+    - C13 Visé par l'art. 42bis du décret du 30/06/1998
+
+    Values pinned against XSD ``MotifExemptionSpecType``. ⚠️ Préfixe ``C0x``
+    partagé avec :class:`MotifExemption` mais sémantique différente.
+    """
+
+    C01 = "C01"
+    C02 = "C02"
+    C03 = "C03"
+    C04 = "C04"
+    C05 = "C05"
+    C06 = "C06"
+    C07 = "C07"
+    C08 = "C08"
+    C09 = "C09"
+    C10 = "C10"
+    C11 = "C11"
+    C12 = "C12"
+    C13 = "C13"
+
+
+class TypeEnseignement(str, Enum):
+    """Type d'enseignement (TypeEnseignementType).
+
+    Used in ``SepsAdmission.typeEnseignement`` (obligatoire si
+    ``codeAdmission == "TITREBEL"``). PRI primaire ; SIPE/SSPE secondaire
+    inf./sup. plein exercice ; SIPS/SSPS secondaire inf./sup. promotion
+    sociale ; SCPE/SLPE supérieur court/long plein exercice ; SCPS/SLPS
+    supérieur court/long promotion sociale. Pinned against XSD
+    ``TypeEnseignementType``.
+    """
+
+    PRI = "PRI"
+    SIPE = "SIPE"
+    SSPE = "SSPE"
+    SIPS = "SIPS"
+    SSPS = "SSPS"
+    SCPE = "SCPE"
+    SLPE = "SLPE"
+    SCPS = "SCPS"
+    SLPS = "SLPS"
+
+
+class TitreDelivre(str, Enum):
+    """Titre délivré (TitreDelivreType, 23 valeurs).
+
+    Used in ``SepsAdmission.titreDelivre`` (obligatoire si
+    ``codeAdmission == "TITREBEL"``, applicabilité selon ``typeEnseignement``).
+    Members are the canonical ETNIC codes. Pinned against XSD
+    ``TitreDelivreType``.
+    """
+
+    CEB = "CEB"
+    CE1D = "CE1D"
+    CESI = "CESI"
+    CE2D = "CE2D"
+    CQ4 = "CQ4"
+    CESSG = "CESSG"
+    CESST = "CESST"
+    CESSQ = "CESSQ"
+    CESSP = "CESSP"
+    CESSA = "CESSA"
+    CE6P = "CE6P"
+    CQ6 = "CQ6"
+    CQ7 = "CQ7"
+    DAES = "DAES"
+    BES = "BES"
+    BACH = "BACH"
+    MAST = "MAST"
+    CESS = "CESS"
+    CQSUP = "CQSUP"
+    CQINF = "CQINF"
+    MASTSPE = "MASTSPE"
+    DOC = "DOC"
+    BACHSPE = "BACHSPE"
+
+
+class Equivalence(str, Enum):
+    """Équivalence d'un titre étranger (EquivalenceType).
+
+    Used in ``SepsAdmission.equivalence`` (obligatoire si
+    ``codeAdmission == "TITREETR"``). Pinned against XSD ``EquivalenceType``.
+    """
+
+    SECONDAIRE_INFERIEUR = "C01"
+    SECONDAIRE_SUPERIEUR = "C02"
+    SUPERIEUR = "C03"
+    CEB = "C04"
+
+
+class ValorisationAcquis(str, Enum):
+    """Valorisation des acquis à l'admission (ValorisationAcquisType).
+
+    Used in ``SepsAdmission.valorisationAcquis`` (obligatoire si
+    ``codeAdmission == "AUTRE"``). C01-C04 valorisation formelle V1-V4 ;
+    C10 VANFI Test/Épreuve ; C20 VANFI Dossier ; C30 Autres ; C40 Aucun titre
+    requis. Distinct de :class:`ValorisationAcquisSanction`. Pinned against
+    XSD ``ValorisationAcquisType``.
+    """
+
+    C01 = "C01"
+    C02 = "C02"
+    C03 = "C03"
+    C04 = "C04"
+    C10 = "C10"
+    C20 = "C20"
+    C30 = "C30"
+    C40 = "C40"
+
+
+class ValorisationAcquisSanction(str, Enum):
+    """Valorisation des acquis en sanction (ValorisationAcquisSanctionType).
+
+    Used in ``SepsSanction.valorisationAcquisSanction`` (obligatoire si
+    ``codeSanction == "RE"``). C00 Réussite ; C01-C04 valorisation formelle
+    V1-V4 ; C05 VANFI Test/Épreuves. Distinct de :class:`ValorisationAcquis`
+    (pas de C00/C05, mais C10-C40). Pinned against XSD
+    ``ValorisationAcquisSanctionType``.
+    """
+
+    C00 = "C00"
+    C01 = "C01"
+    C02 = "C02"
+    C03 = "C03"
+    C04 = "C04"
+    C05 = "C05"
+
+
+class StatutFinFormation(str, Enum):
+    """Statut de fin de formation (StatutFinFormationType, FSE).
+
+    Used in ``SepsSanction.statutFinFormation`` (obligatoire si UE FSE).
+    ⚠️ Le XSD impose ``C01``-``C06`` ; le manuel PDF écrit ``01``-``06`` (sans
+    « C ») — **le XSD fait foi**.
+
+    - C01 Mise à l'emploi après la formation
+    - C02 Poursuite d'une formation dans le cadre du PI
+    - C03 Poursuite d'une formation hors du cadre du PI
+    - C04 Aide à la recherche d'emploi après la formation
+    - C05 Réorientation vers un autre type d'action
+    - C06 Fin de formation sans suite connue
+    """
+
+    C01 = "C01"
+    C02 = "C02"
+    C03 = "C03"
+    C04 = "C04"
+    C05 = "C05"
+    C06 = "C06"
+
+
+class CodeNiveau(str, Enum):
+    """Code niveau d'une UE (CodeNiveauType).
+
+    Used in ``SepsUE.codeNiveau`` (lecture). Pinned against XSD
+    ``CodeNiveauType``.
+    """
+
+    SI = "SI"
+    SS = "SS"
+    SC = "SC"
+    SL = "SL"
+
+
 # ---------------------------------------------------------------------------
 # Backwards compatibility: preserve the legacy list constant.
 # Derived from TypeInterventionExterieure so the two never drift.

--- a/pyetnic/seps/__init__.py
+++ b/pyetnic/seps/__init__.py
@@ -25,6 +25,19 @@ from ..nomenclatures import (
     MotifAbandon,
     DureeInoccupation,
     SituationMenage,
+    # Énumérations inscription (inscription_v1.xsd)
+    CodeStatut,
+    Indicateur,
+    IndicateurX,
+    MotifExemption,
+    MotifExemptionSpec,
+    TypeEnseignement,
+    TitreDelivre,
+    Equivalence,
+    ValorisationAcquis,
+    ValorisationAcquisSanction,
+    StatutFinFormation,
+    CodeNiveau,
 )
 
 # Modèles
@@ -105,4 +118,17 @@ __all__ = [
     "MotifAbandon",
     "DureeInoccupation",
     "SituationMenage",
+    # Nomenclatures inscription (inscription_v1.xsd)
+    "CodeStatut",
+    "Indicateur",
+    "IndicateurX",
+    "MotifExemption",
+    "MotifExemptionSpec",
+    "TypeEnseignement",
+    "TitreDelivre",
+    "Equivalence",
+    "ValorisationAcquis",
+    "ValorisationAcquisSanction",
+    "StatutFinFormation",
+    "CodeNiveau",
 ]

--- a/pyetnic/services/_helpers.py
+++ b/pyetnic/services/_helpers.py
@@ -152,3 +152,36 @@ def _as_list(value: Any) -> list:
     if isinstance(value, (dict, str, bytes)):
         return [value]
     return list(value)
+
+
+def _flatten_messages(messages: Any) -> list:
+    """Flatten a SOAP ``messagesType`` block into a list of strings.
+
+    ``messagesType`` is a dict with ``error`` / ``warning`` / ``info`` sub-lists
+    of ``MessageType`` ({code, description, zone}); zeep may return a single
+    dict or a list per category. This normalizes the whole block to
+    ``["<code>: <description>", ...]`` — suitable for a ``List[str]`` field such
+    as ``FormationsListeResult.messages`` — instead of leaking the raw dict
+    (which breaks ``" ".join(result.messages)`` and friends).
+
+    Args:
+        messages: The raw ``body['messages']`` value (a dict, or None).
+
+    Returns:
+        A list of human-readable strings, always (empty if no messages).
+    """
+    if not isinstance(messages, dict):
+        return []
+    out: list = []
+    for kind in ("error", "warning", "info"):
+        for msg in _as_list(messages.get(kind)):
+            if isinstance(msg, dict):
+                code = msg.get("code")
+                desc = msg.get("description")
+                parts = [str(code)] if code is not None else []
+                if desc is not None:
+                    parts.append(str(desc))
+                out.append(": ".join(parts) if parts else str(msg))
+            elif msg is not None:
+                out.append(str(msg))
+    return out

--- a/pyetnic/services/_helpers.py
+++ b/pyetnic/services/_helpers.py
@@ -120,24 +120,35 @@ def _as_list(value: Any) -> list:
     Args:
         value: The raw value from zeep's serialized output. Can be:
             - None → returns []
-            - a dict (single element) → returns [dict]
+            - a dict (single complex element) → returns [dict]
+            - a str/bytes (single simple-typed element) → returns [str]
             - a list → returns as-is
 
     Returns:
         A list, always.
 
+    Note:
+        ``str``/``bytes`` are treated as a single scalar element, never as an
+        iterable to walk. zeep returns a bare ``str`` (not a one-element list)
+        when a repeated *simple-typed* element occurs once — e.g. a single
+        ``autrePrenom``. Without this guard, ``list("Karim")`` would explode
+        into ``['K', 'a', 'r', 'i', 'm']``.
+
     Examples:
         # Multiple results → already a list, returned as-is
         _as_list([{'name': 'A'}, {'name': 'B'}])  # → [{'name': 'A'}, {'name': 'B'}]
 
-        # Single result → zeep returned a dict, wrapped in a list
+        # Single complex result → zeep returned a dict, wrapped in a list
         _as_list({'name': 'A'})  # → [{'name': 'A'}]
+
+        # Single simple-typed result → zeep returned a bare str, wrapped (not split)
+        _as_list('Karim')  # → ['Karim']
 
         # No results → empty list
         _as_list(None)  # → []
     """
     if value is None:
         return []
-    if isinstance(value, dict):
+    if isinstance(value, (dict, str, bytes)):
         return [value]
     return list(value)

--- a/pyetnic/services/enregistrer_etudiant.py
+++ b/pyetnic/services/enregistrer_etudiant.py
@@ -6,7 +6,7 @@ from typing import Optional
 from ..soap_client import SoapClientManager
 from ._helpers import to_soap_dict
 from .models import Etudiant, EtudiantDetailsSave
-from .seps import RechercheEtudiantsService
+from .seps import RechercheEtudiantsService, _check_seps_errors
 
 logger = logging.getLogger(__name__)
 
@@ -33,6 +33,7 @@ class EnregistrerEtudiantService:
     # ------------------------------------------------------------------
 
     def _parse_enregistrer_response(self, result) -> Optional[Etudiant]:
+        _check_seps_errors(result)
         if not (
             result
             and result.get("body")
@@ -43,6 +44,7 @@ class EnregistrerEtudiantService:
         return self._parse_etudiant(result["body"]["response"]["etudiant"])
 
     def _parse_modifier_response(self, result) -> Optional[Etudiant]:
+        _check_seps_errors(result)
         if not (
             result
             and result.get("body")

--- a/pyetnic/services/formations_liste.py
+++ b/pyetnic/services/formations_liste.py
@@ -11,7 +11,7 @@ from typing import Any, Optional
 from ..soap_client import SoapClientManager, SoapError
 from ..config import Config
 from ..exceptions import extract_error_info, map_etnic_error_code_to_class
-from ._helpers import _as_list
+from ._helpers import _as_list, _flatten_messages
 from .models import Formation, FormationsListeResult, OrganisationApercu, OrganisationId, StatutDocument
 import logging
 from pprint import pformat
@@ -62,7 +62,7 @@ class FormationsListeService:
                         description=description,
                         request_id=request_id,
                     )
-                return FormationsListeResult(False, [], messages=result['body'].get('messages', []))
+                return FormationsListeResult(False, [], messages=_flatten_messages(result['body'].get('messages')))
 
         except SoapError as e:
             if Config.RAISE_ON_ERROR:
@@ -135,7 +135,7 @@ class FormationsListeService:
                         description=description,
                         request_id=request_id,
                     )
-                return FormationsListeResult(False, [], messages=result['body'].get('messages', []))
+                return FormationsListeResult(False, [], messages=_flatten_messages(result['body'].get('messages')))
 
         except SoapError as e:
             if Config.RAISE_ON_ERROR:

--- a/pyetnic/services/models.py
+++ b/pyetnic/services/models.py
@@ -133,7 +133,13 @@ class FormationDocument1:
 
 @dataclass
 class Doc2ActiviteEnseignementLine:
-    """Ligne d'activité d'enseignement pour le document 2."""
+    """Ligne d'activité d'enseignement pour le document 2.
+
+    Ordre et types alignés sur le XSD ``Doc2ActiviteEnseignementLineCT`` (cf.
+    ``specs/04_formation_periodes_v1.md``) : les 14 champs sont obligatoires en
+    réponse, ``coEtuReg`` (année d'études Rgp, string) vient en dernier après
+    les trois numéros de regroupement ``coAdmReg``/``coOrgReg``/``coBraReg`` (int).
+    """
     coNumBranche: int
     coCategorie: str
     teNomBranche: str
@@ -144,10 +150,10 @@ class Doc2ActiviteEnseignementLine:
     nbPeriodePrevueAn2: float
     nbPeriodeReelleAn1: float
     nbPeriodeReelleAn2: float
+    coAdmReg: int
+    coOrgReg: int
+    coBraReg: int
     coEtuReg: str
-    coAdmReg: int = 0
-    coOrgReg: int = 0
-    coBraReg: int = 0
 
 @dataclass
 class Doc2ActiviteEnseignementList:

--- a/pyetnic/services/models.py
+++ b/pyetnic/services/models.py
@@ -525,7 +525,15 @@ class SepsUESave:
 
 @dataclass
 class SepsSpecificiteSave:
-    """Spécificités d'inscription à envoyer (SpecificiteDataInputType — sans regulier1/5)."""
+    """Spécificités d'inscription à envoyer (SpecificiteDataType).
+
+    L'élément d'entrée ``inscription/specificite`` est typé ``SpecificiteDataType``
+    (inscription_v1.xsd l.18), et non ``SpecificiteDataInputType`` — ce dernier
+    est un type XSD mort, jamais référencé. Le contrat d'entrée porte donc bien
+    ``regulier1`` / ``regulier5`` (IndicateurType, "O"/"N").
+    """
+    regulier1: Optional[str] = None                       # "O" | "N"
+    regulier5: Optional[str] = None                       # "O" | "N"
     droitInscription: Optional[SepsDroitInscription] = None
     droitInscriptionSpecifique: Optional[SepsDroitInscriptionSpecifique] = None
     dureeInoccupation: Optional[str] = None               # C00|C06|C12|C24

--- a/pyetnic/services/organisation.py
+++ b/pyetnic/services/organisation.py
@@ -1,7 +1,7 @@
 from datetime import date
 from pprint import pformat
 from typing import Optional
-from ._helpers import organisation_request_id
+from ._helpers import organisation_request_id, _strip_none_recursive
 from .models import Organisation, OrganisationId, StatutDocument
 from ..exceptions import signal_business_error
 from ..soap_client import SoapClientManager
@@ -134,7 +134,11 @@ class OrganisationService:
             'typeInterventionExterieure': typeInterventionExterieure,
             'interventionExterieure50p': interventionExterieure50p,
         }
-        result = self.client_manager.call_service("CreerOrganisation", **request_data)
+        # Strip None-valued optional fields: zeep would otherwise emit empty
+        # XML elements that ETNIC interprets as "erase this value" (D2 defect).
+        result = self.client_manager.call_service(
+            "CreerOrganisation", **_strip_none_recursive(request_data)
+        )
         # L'id complet (avec numOrganisation) est dans la réponse
         return self._parse_organisation_response(result)
 
@@ -156,7 +160,11 @@ class OrganisationService:
             'typeInterventionExterieure': organisation.typeInterventionExterieure,
             'interventionExterieure50p': organisation.interventionExterieure50p,
         }
-        result = self.client_manager.call_service("ModifierOrganisation", **request_data)
+        # Strip None-valued optional fields (D2): an empty XML element would be
+        # read by ETNIC as "erase", causing partial-update corruption on modify.
+        result = self.client_manager.call_service(
+            "ModifierOrganisation", **_strip_none_recursive(request_data)
+        )
         return self._parse_organisation_response(result, organisation.id)
 
     def supprimer_organisation(self, organisation_id: OrganisationId) -> bool:

--- a/pyetnic/services/seps.py
+++ b/pyetnic/services/seps.py
@@ -12,6 +12,11 @@ logger = logging.getLogger(__name__)
 
 _NISS_RE = re.compile(r'[0-9]{6}-?[0-9]{3}-?[0-9]{2}')
 
+# Codes SEPS signifiant « aucun résultat » : ils NE doivent PAS lever
+# d'exception — le contrat « non trouvé » se traduit par None / [] côté
+# appelant (lireEtudiant : 30110 fin de traitement, 30115 warning).
+_NOT_FOUND_CODES = frozenset({"30110", "30115"})
+
 
 class SepsEtnicError(Exception):
     """Erreur retournée par le serveur ETNIC SEPS (success=False).
@@ -72,6 +77,48 @@ class NissMutationError(SepsEtnicError):
             f"NISS {ancien_niss!r} remplacé par {nouveau_niss!r} — "
             "relancer la recherche avec nouveau_niss",
         )
+
+
+def _check_seps_errors(result, *, ancien_niss: Optional[str] = None) -> None:
+    """Inspecte le bloc retour SEPS et lève une exception typée si success=False.
+
+    Partagé par tous les services SEPS Étudiant (recherche, lecture,
+    enregistrement, modification) pour éviter que les erreurs métier soient
+    avalées silencieusement (un simple ``return None`` masquerait un certificat
+    invalide, une mutation NISS, un doublon…).
+
+    Les codes « aucun résultat » (``_NOT_FOUND_CODES``) sont ignorés : la
+    méthode appelante renverra alors None / [] de façon intentionnelle.
+
+    Args:
+        result: La réponse SOAP désérialisée (dict avec clé ``body``).
+        ancien_niss: Le NISS de la requête, propagé dans ``NissMutationError``.
+
+    Raises:
+        NissMutationError: code 30401.
+        TropDeResultatsError: code 30501.
+        SepsAuthError: code 30550.
+        SepsEtnicError: tout autre code métier.
+    """
+    if not (result and result.get("body")):
+        return
+    body = result["body"]
+    if body.get("success", True):
+        return
+    errors = (body.get("messages") or {}).get("error") or []
+    for err in (errors if isinstance(errors, list) else [errors]):
+        code = str(err.get("code"))
+        if code in _NOT_FOUND_CODES:
+            continue
+        desc = err.get("description", "")
+        if code == "30401":
+            match = _NISS_RE.search(desc)
+            raise NissMutationError(ancien_niss or "", match.group(0) if match else "")
+        if code == "30501":
+            raise TropDeResultatsError()
+        if code == "30550":
+            raise SepsAuthError(code, desc)
+        raise SepsEtnicError(code, desc)
 
 
 class RechercheEtudiantsService:
@@ -135,7 +182,7 @@ class RechercheEtudiantsService:
             niss=d.get("niss"),
             nom=d.get("nom"),
             prenom=d.get("prenom"),
-            autrePrenom=list(autre_prenom_raw) if autre_prenom_raw else None,
+            autrePrenom=_as_list(autre_prenom_raw) or None,
             sexe=d.get("sexe"),
             naissance=RechercheEtudiantsService._parse_naissance(d.get("naissance")),
             deces=SepsDeces(date=deces_d.get("date")) if deces_d else None,
@@ -154,6 +201,7 @@ class RechercheEtudiantsService:
         )
 
     def _parse_lire_etudiant_response(self, result) -> Optional[Etudiant]:
+        _check_seps_errors(result)
         if not (
             result
             and result.get("body")
@@ -164,22 +212,7 @@ class RechercheEtudiantsService:
         return self._parse_etudiant(result["body"]["response"]["etudiant"])
 
     def _parse_rechercher_etudiants_response(self, result, ancien_niss: Optional[str] = None) -> List[Etudiant]:
-        if result and result.get("body"):
-            body = result["body"]
-            if not body.get("success", True):
-                errors = (body.get("messages") or {}).get("error") or []
-                for err in (errors if isinstance(errors, list) else [errors]):
-                    code = str(err.get("code"))
-                    if code == "30401":
-                        match = _NISS_RE.search(err.get("description", ""))
-                        nouveau_niss = match.group(0) if match else ""
-                        raise NissMutationError(ancien_niss or "", nouveau_niss)
-                    elif code == "30501":
-                        raise TropDeResultatsError()
-                    elif code == "30550":
-                        raise SepsAuthError(code, err.get("description", ""))
-                    else:
-                        raise SepsEtnicError(code, err.get("description", ""))
+        _check_seps_errors(result, ancien_niss=ancien_niss)
         if not (
             result
             and result.get("body")

--- a/pyetnic/soap_client.py
+++ b/pyetnic/soap_client.py
@@ -11,7 +11,7 @@ import logging
 import urllib3
 from importlib.resources import files, as_file
 
-from zeep import Client
+from zeep import Client, Settings
 from zeep.helpers import serialize_object
 from zeep.wsse.username import UsernameToken
 from zeep.transports import Transport
@@ -200,7 +200,11 @@ class SoapClientManager:
         transport = Transport(session=session)
 
         wsdl_path = get_wsdl_path('pyetnic.resources', self.service_config.wsdl_path)
-        client = Client(wsdl_path, wsse=wsse, transport=transport)
+        # Non-strict parsing: ETNIC production responses may carry elements absent
+        # from the embedded WSDL/XSD (e.g. the SEPS inscription `audit` block), which
+        # zeep's default strict mode rejects. Tolerate unknown elements instead.
+        settings = Settings(strict=False)
+        client = Client(wsdl_path, wsse=wsse, transport=transport, settings=settings)
         service = client.create_service(self.service_config.binding_name, self.service_config.endpoint)
 
         self._client_cache[key] = service

--- a/tests/regression/fixtures/seps_responses.py
+++ b/tests/regression/fixtures/seps_responses.py
@@ -111,3 +111,41 @@ GENERIC_SEPS_ERROR_RESPONSE: dict = {
         },
     },
 }
+
+# success=False carrying a NOT_FOUND code (30115): the "non trouvé" contract
+# must yield None / [] — it must NOT raise, even if ETNIC files it under error.
+NOT_FOUND_SEPS_RESPONSE: dict = {
+    "body": {
+        "success": False,
+        "messages": {
+            "error": [
+                {"code": "30115", "description": "Aucun étudiant trouvé"},
+            ],
+        },
+    },
+}
+
+# zeep returns a bare str (not a one-element list) when a repeated simple-typed
+# element (autrePrenom) occurs exactly once.
+ETUDIANT_SINGLE_AUTRE_PRENOM_DICT: dict = {
+    "cfNum": "1234567-89",
+    "rnDetails": {
+        "niss": "85010112345",
+        "nom": "Dupont",
+        "prenom": "Jean",
+        "autrePrenom": "Karim",
+        "sexe": "M",
+        "naissance": None,
+        "deces": None,
+        "adresse": None,
+        "codeNationalite": "BE",
+    },
+    "cfwbDetails": None,
+}
+
+LIRE_ETUDIANT_SINGLE_AUTRE_PRENOM_RESPONSE: dict = {
+    "body": {
+        "success": True,
+        "response": {"etudiant": ETUDIANT_SINGLE_AUTRE_PRENOM_DICT},
+    },
+}

--- a/tests/regression/test_exceptions.py
+++ b/tests/regression/test_exceptions.py
@@ -137,3 +137,56 @@ def test_specialized_business_errors_inherit_constructor():
 
     val = EtnicValidationError("bad input", code="X")
     assert val.code == "X"
+
+
+# ---------------------------------------------------------------------------
+# extract_error_info — requestId resolution (latent bug #4)
+# ---------------------------------------------------------------------------
+
+def test_extract_error_info_reads_header_request_id():
+    """v1/v3 services carry requestId in a SOAP header."""
+    from pyetnic.exceptions import extract_error_info
+
+    result = {
+        "header": {"requestId": "header-rid"},
+        "body": {
+            "success": False,
+            "messages": {"error": [{"code": "00009", "description": "rien"}]},
+        },
+    }
+    code, _, request_id = extract_error_info(result)
+    assert code == "00009"
+    assert request_id == "header-rid"
+
+
+def test_extract_error_info_falls_back_to_body_request_id():
+    """Common_v2 (Organisation v7) carries requestId as a body attribute, not a
+    SOAP header — extract_error_info must still surface it."""
+    from pyetnic.exceptions import extract_error_info
+
+    result = {
+        "body": {
+            "requestId": "body-rid",
+            "success": False,
+            "messages": {"error": [{"code": "30004", "description": "type IE incorrect"}]},
+        },
+    }
+    code, _, request_id = extract_error_info(result)
+    assert code == "30004"
+    assert request_id == "body-rid"
+
+
+def test_extract_error_info_header_request_id_takes_precedence():
+    """When both are present, the header value wins (non-regressive)."""
+    from pyetnic.exceptions import extract_error_info
+
+    result = {
+        "header": {"requestId": "header-rid"},
+        "body": {
+            "requestId": "body-rid",
+            "success": False,
+            "messages": {"error": [{"code": "1", "description": "x"}]},
+        },
+    }
+    _, _, request_id = extract_error_info(result)
+    assert request_id == "header-rid"

--- a/tests/regression/test_public_api_seps_read.py
+++ b/tests/regression/test_public_api_seps_read.py
@@ -36,7 +36,9 @@ from .fixtures.seps_responses import (
     EMPTY_RECHERCHER_ETUDIANTS_RESPONSE,
     GENERIC_SEPS_ERROR_RESPONSE,
     LIRE_ETUDIANT_NONE_RESPONSE,
+    LIRE_ETUDIANT_SINGLE_AUTRE_PRENOM_RESPONSE,
     NISS_MUTATION_ERROR_RESPONSE,
+    NOT_FOUND_SEPS_RESPONSE,
     SEPS_AUTH_ERROR_RESPONSE,
     TROP_DE_RESULTATS_ERROR_RESPONSE,
 )
@@ -70,6 +72,30 @@ class TestLireEtudiant:
     def test_none_response(self, mock_soap_call):
         mock_soap_call.return_value = LIRE_ETUDIANT_NONE_RESPONSE
         assert lire_etudiant("1234567-89") is None
+
+    def test_auth_error_raises_not_swallowed(self, mock_soap_call):
+        """A business error (here 30550) must raise, not return None silently."""
+        mock_soap_call.return_value = SEPS_AUTH_ERROR_RESPONSE
+        with pytest.raises(SepsAuthError) as exc_info:
+            lire_etudiant("1234567-89")
+        assert exc_info.value.code == "30550"
+
+    def test_generic_error_raises_not_swallowed(self, mock_soap_call):
+        mock_soap_call.return_value = GENERIC_SEPS_ERROR_RESPONSE
+        with pytest.raises(SepsEtnicError) as exc_info:
+            lire_etudiant("1234567-89")
+        assert exc_info.value.code == "30999"
+
+    def test_not_found_code_returns_none(self, mock_soap_call):
+        """A NOT_FOUND code (30115) is 'no result', not an error → None."""
+        mock_soap_call.return_value = NOT_FOUND_SEPS_RESPONSE
+        assert lire_etudiant("1234567-89") is None
+
+    def test_single_autre_prenom_not_char_split(self, mock_soap_call):
+        """A single autrePrenom returned as a bare str must stay ['Karim']."""
+        mock_soap_call.return_value = LIRE_ETUDIANT_SINGLE_AUTRE_PRENOM_RESPONSE
+        et = lire_etudiant("1234567-89")
+        assert et.rnDetails.autrePrenom == ["Karim"]
 
     def test_request_shape_default(self, mock_soap_call):
         mock_soap_call.return_value = CANONICAL_LIRE_ETUDIANT_RESPONSE
@@ -150,6 +176,11 @@ class TestRechercherEtudiants:
 
     def test_empty_response(self, mock_soap_call):
         mock_soap_call.return_value = EMPTY_RECHERCHER_ETUDIANTS_RESPONSE
+        assert rechercher_etudiants(niss="00000000000") == []
+
+    def test_not_found_code_returns_empty(self, mock_soap_call):
+        """A NOT_FOUND code (30115) yields [] rather than raising."""
+        mock_soap_call.return_value = NOT_FOUND_SEPS_RESPONSE
         assert rechercher_etudiants(niss="00000000000") == []
 
     def test_no_args_raises_value_error(self, mock_soap_call):

--- a/tests/unit/test_document2_unit.py
+++ b/tests/unit/test_document2_unit.py
@@ -1,17 +1,37 @@
 # test_document2_unit.py — mock-only unit tests for Document2Service.
 
 import logging
+from dataclasses import MISSING, fields
 
 import pytest
 
 from pyetnic.config import Config
 from pyetnic.services.document2 import Document2Service
 from pyetnic.services.models import (
+    Doc2ActiviteEnseignementLine,
     Doc2ActiviteEnseignementLineSave,
     Doc2ActiviteEnseignementListSave,
     FormationDocument2,
     OrganisationId,
 )
+
+
+def test_doc2_activite_line_field_order_matches_xsd():
+    """Field order must follow the XSD (coEtuReg last), with no misleading
+    ``=0`` defaults on the four required regroupement fields — guards against
+    the positional-construction hazard (latent bug #3)."""
+    names = [f.name for f in fields(Doc2ActiviteEnseignementLine)]
+    assert names == [
+        "coNumBranche", "coCategorie", "teNomBranche", "coAnnEtude", "nbEleveC1",
+        "nbPeriodeBranche", "nbPeriodePrevueAn1", "nbPeriodePrevueAn2",
+        "nbPeriodeReelleAn1", "nbPeriodeReelleAn2",
+        "coAdmReg", "coOrgReg", "coBraReg", "coEtuReg",
+    ]
+    by_name = {f.name: f for f in fields(Doc2ActiviteEnseignementLine)}
+    for required in ("coAdmReg", "coOrgReg", "coBraReg", "coEtuReg"):
+        assert by_name[required].default is MISSING, (
+            f"{required} is required in the response — it must not carry a default"
+        )
 
 logger = logging.getLogger(__name__)
 

--- a/tests/unit/test_formations_liste_unit.py
+++ b/tests/unit/test_formations_liste_unit.py
@@ -63,6 +63,44 @@ def test_lister_formations_organisables_does_not_swallow_unexpected_exceptions(m
         svc.lister_formations_organisables()
 
 
+def test_lister_formations_flattens_messages_block(monkeypatch):
+    """On success=False, messages must be a flat List[str], not the raw dict."""
+    svc = FormationsListeService()
+    mock_response = {
+        "body": {
+            "success": False,
+            "messages": {
+                "error": [{"code": "00009", "description": "Aucun enregistrement"}],
+                "warning": {"code": "12345", "description": "Attention"},
+            },
+        }
+    }
+    monkeypatch.setattr(svc.client_manager, "call_service", lambda *a, **kw: mock_response)
+
+    result = svc.lister_formations()
+
+    assert result.success is False
+    assert result.messages == ["00009: Aucun enregistrement", "12345: Attention"]
+    assert all(isinstance(m, str) for m in result.messages)
+
+
+def test_lister_formations_organisables_flattens_messages_block(monkeypatch):
+    """Same flattening contract for lister_formations_organisables."""
+    svc = FormationsListeService()
+    mock_response = {
+        "body": {
+            "success": False,
+            "messages": {"error": [{"code": "30001", "description": "Établissement incorrect"}]},
+        }
+    }
+    monkeypatch.setattr(svc.client_manager, "call_service", lambda *a, **kw: mock_response)
+
+    result = svc.lister_formations_organisables()
+
+    assert result.success is False
+    assert result.messages == ["30001: Établissement incorrect"]
+
+
 def test_lister_formations_mock_response(monkeypatch):
     svc = FormationsListeService()
     mock_response = {

--- a/tests/unit/test_helpers.py
+++ b/tests/unit/test_helpers.py
@@ -195,3 +195,18 @@ class TestAsList:
         """A list with one element must NOT be unwrapped."""
         items = [{'name': 'A'}]
         assert _as_list(items) == [{'name': 'A'}]
+
+    def test_str_treated_as_scalar_not_char_split(self):
+        """A bare str (single simple-typed element) must be wrapped, not split.
+
+        zeep returns a bare ``str`` when a repeated simple-typed element occurs
+        once (e.g. a single ``autrePrenom``). ``list('Karim')`` would explode
+        into individual characters — the bug this guard prevents.
+        """
+        assert _as_list('Karim') == ['Karim']
+
+    def test_bytes_treated_as_scalar(self):
+        assert _as_list(b'x') == [b'x']
+
+    def test_str_list_returned_as_is(self):
+        assert _as_list(['Marc', 'Karim']) == ['Marc', 'Karim']

--- a/tests/unit/test_helpers.py
+++ b/tests/unit/test_helpers.py
@@ -5,7 +5,12 @@ from typing import List, Optional
 
 import pytest
 
-from pyetnic.services._helpers import _as_list, organisation_request_id, to_soap_dict
+from pyetnic.services._helpers import (
+    _as_list,
+    _flatten_messages,
+    organisation_request_id,
+    to_soap_dict,
+)
 from pyetnic.services.models import OrganisationId
 
 
@@ -210,3 +215,37 @@ class TestAsList:
 
     def test_str_list_returned_as_is(self):
         assert _as_list(['Marc', 'Karim']) == ['Marc', 'Karim']
+
+
+# ---------------------------------------------------------------------------
+# _flatten_messages
+# ---------------------------------------------------------------------------
+
+class TestFlattenMessages:
+
+    def test_none_returns_empty_list(self):
+        assert _flatten_messages(None) == []
+
+    def test_non_dict_returns_empty_list(self):
+        assert _flatten_messages("oops") == []
+
+    def test_flattens_error_list(self):
+        block = {"error": [{"code": "00009", "description": "Aucun enregistrement"}]}
+        assert _flatten_messages(block) == ["00009: Aucun enregistrement"]
+
+    def test_single_dict_per_category_is_normalized(self):
+        """zeep may return a single dict (not a list) for one message."""
+        block = {"warning": {"code": "12345", "description": "Attention"}}
+        assert _flatten_messages(block) == ["12345: Attention"]
+
+    def test_orders_error_warning_info(self):
+        block = {
+            "info": [{"code": "200", "description": "ok"}],
+            "error": [{"code": "1", "description": "err"}],
+            "warning": [{"code": "2", "description": "warn"}],
+        }
+        assert _flatten_messages(block) == ["1: err", "2: warn", "200: ok"]
+
+    def test_returns_only_strings(self):
+        block = {"error": [{"code": "1", "description": "x"}]}
+        assert all(isinstance(m, str) for m in _flatten_messages(block))

--- a/tests/unit/test_nomenclatures.py
+++ b/tests/unit/test_nomenclatures.py
@@ -2,14 +2,28 @@
 
 from __future__ import annotations
 
+import pytest
+
 from pyetnic.nomenclatures import (
     CodeAdmission,
+    CodeNiveau,
     CodeSanction,
+    CodeStatut,
     DureeInoccupation,
+    Equivalence,
+    Indicateur,
+    IndicateurX,
     MotifAbandon,
+    MotifExemption,
+    MotifExemptionSpec,
     SituationMenage,
+    StatutFinFormation,
+    TitreDelivre,
     TYPES_INTERVENTION_EXTERIEURE,
+    TypeEnseignement,
     TypeInterventionExterieure,
+    ValorisationAcquis,
+    ValorisationAcquisSanction,
 )
 
 
@@ -94,6 +108,81 @@ class TestSituationMenage:
     def test_xsd_values_present(self):
         values = {m.value for m in SituationMenage}
         assert values == {"ISOL", "SSEM", "A1EM", "X"}
+
+
+# ---------------------------------------------------------------------------
+# Inscription enums — drift guards pinned against inscription_v1.xsd
+# ---------------------------------------------------------------------------
+
+# (enum, exact set of XSD enumeration values)
+_INSCRIPTION_ENUM_XSD_VALUES = [
+    (CodeStatut, {"DE", "AN"}),
+    (Indicateur, {"O", "N"}),
+    (IndicateurX, {"O", "N", "X"}),
+    (MotifExemption, {"C01", "C02", "C03", "C04", "C05", "C06", "C07"}),
+    (MotifExemptionSpec, {f"C{n:02d}" for n in range(1, 14)}),
+    (TypeEnseignement, {"PRI", "SIPE", "SSPE", "SIPS", "SSPS", "SCPE", "SLPE", "SCPS", "SLPS"}),
+    (TitreDelivre, {
+        "CEB", "CE1D", "CESI", "CE2D", "CQ4", "CESSG", "CESST", "CESSQ", "CESSP",
+        "CESSA", "CE6P", "CQ6", "CQ7", "DAES", "BES", "BACH", "MAST", "CESS",
+        "CQSUP", "CQINF", "MASTSPE", "DOC", "BACHSPE",
+    }),
+    (Equivalence, {"C01", "C02", "C03", "C04"}),
+    (ValorisationAcquis, {"C01", "C02", "C03", "C04", "C10", "C20", "C30", "C40"}),
+    (ValorisationAcquisSanction, {"C00", "C01", "C02", "C03", "C04", "C05"}),
+    (StatutFinFormation, {"C01", "C02", "C03", "C04", "C05", "C06"}),
+    (CodeNiveau, {"SI", "SS", "SC", "SL"}),
+]
+
+
+@pytest.mark.parametrize(
+    "enum_cls, expected",
+    _INSCRIPTION_ENUM_XSD_VALUES,
+    ids=[e.__name__ for e, _ in _INSCRIPTION_ENUM_XSD_VALUES],
+)
+def test_inscription_enum_values_match_xsd(enum_cls, expected):
+    """Each inscription enum must carry exactly the XSD enumeration values."""
+    assert {m.value for m in enum_cls} == expected
+
+
+@pytest.mark.parametrize(
+    "enum_cls",
+    [e for e, _ in _INSCRIPTION_ENUM_XSD_VALUES],
+    ids=[e.__name__ for e, _ in _INSCRIPTION_ENUM_XSD_VALUES],
+)
+def test_inscription_enum_members_are_str(enum_cls):
+    """Every member must be a str subclass that compares to its raw value."""
+    for m in enum_cls:
+        assert isinstance(m, str)
+        assert m == m.value
+
+
+def test_titre_delivre_has_23_members():
+    assert len(TitreDelivre) == 23
+
+
+def test_statut_fin_formation_uses_c_prefix_not_bare_digits():
+    """XSD imposes C01-C06; the PDF's bare 01-06 must never sneak in."""
+    assert {m.value for m in StatutFinFormation} == {f"C{n:02d}" for n in range(1, 7)}
+    assert "01" not in {m.value for m in StatutFinFormation}
+
+
+def test_indicateur_and_indicateurx_are_distinct():
+    assert "X" not in {m.value for m in Indicateur}
+    assert "X" in {m.value for m in IndicateurX}
+
+
+def test_new_inscription_enums_exported_from_seps_namespace():
+    import pyetnic.seps as seps
+
+    for name in (
+        "CodeStatut", "Indicateur", "IndicateurX", "MotifExemption",
+        "MotifExemptionSpec", "TypeEnseignement", "TitreDelivre", "Equivalence",
+        "ValorisationAcquis", "ValorisationAcquisSanction", "StatutFinFormation",
+        "CodeNiveau",
+    ):
+        assert hasattr(seps, name), f"missing seps export: {name}"
+        assert name in seps.__all__
 
 
 class TestLegacyConstant:

--- a/tests/unit/test_organisation_unit.py
+++ b/tests/unit/test_organisation_unit.py
@@ -134,6 +134,93 @@ def test_modifier_organisation_mock(service, monkeypatch):
     assert result.id == org_id
 
 
+def test_creer_organisation_strips_none_from_payload(service, monkeypatch):
+    """None-valued optional fields must be absent from the CreerOrganisation payload.
+
+    zeep would otherwise serialize them as empty XML elements that ETNIC reads
+    as 'erase this value' (D2 defect — previously unfixed on organisation).
+    """
+    captured: dict = {}
+
+    def fake_call(method_name, **kwargs):
+        captured["method"] = method_name
+        captured["kwargs"] = kwargs
+        return _mock_org_response("2023-2024", 3052, 328, 99)
+
+    monkeypatch.setattr(service.client_manager, "call_service", fake_call)
+
+    service.creer_organisation(
+        annee_scolaire="2023-2024",
+        etab_id=3052, impl_id=6050,
+        num_adm_formation=328,
+        date_debut=date(2024, 9, 2),
+        date_fin=date(2025, 6, 27),
+        valorisationAcquis=True,
+    )
+
+    kwargs = captured["kwargs"]
+    assert captured["method"] == "CreerOrganisation"
+    # implId IS sent on create (required there, unlike Lire/Modifier)
+    assert kwargs["id"] == {
+        "anneeScolaire": "2023-2024",
+        "etabId": 3052,
+        "implId": 6050,
+        "numAdmFormation": 328,
+    }
+    assert kwargs["valorisationAcquis"] is True
+    for absent in (
+        "organisationPeriodesSupplOuEPT",
+        "enPrison",
+        "reorientation7TP",
+        "activiteFormation",
+        "conseillerPrevention",
+        "enseignementHybride",
+        "numOrganisation2AnneesScolaires",
+        "typeInterventionExterieure",
+        "interventionExterieure50p",
+    ):
+        assert absent not in kwargs, f"expected {absent!r} to be stripped"
+
+
+def test_modifier_organisation_strips_none_from_payload(service, monkeypatch):
+    """None-valued optional fields must be absent from the ModifierOrganisation payload."""
+    captured: dict = {}
+
+    def fake_call(method_name, **kwargs):
+        captured["method"] = method_name
+        captured["kwargs"] = kwargs
+        return _mock_org_response("2023-2024", 3052, 328, 1)
+
+    monkeypatch.setattr(service.client_manager, "call_service", fake_call)
+
+    org_id = OrganisationId(
+        anneeScolaire="2023-2024", etabId=3052,
+        numAdmFormation=328, numOrganisation=1, implId=6050,
+    )
+    org = Organisation(
+        id=org_id,
+        dateDebutOrganisation=date(2024, 9, 2),
+        dateFinOrganisation=date(2025, 6, 27),
+        enPrison=True,
+    )
+
+    service.modifier_organisation(org)
+
+    kwargs = captured["kwargs"]
+    assert captured["method"] == "ModifierOrganisation"
+    # implId must NOT be sent on modify (organisation_request_id excludes it)
+    assert "implId" not in kwargs["id"]
+    assert kwargs["enPrison"] is True
+    for absent in (
+        "valorisationAcquis",
+        "reorientation7TP",
+        "activiteFormation",
+        "typeInterventionExterieure",
+        "interventionExterieure50p",
+    ):
+        assert absent not in kwargs, f"expected {absent!r} to be stripped"
+
+
 def test_supprimer_organisation_mock_succes(service, monkeypatch):
     """Vérifie que supprimer_organisation retourne True si success=True."""
     org_id = OrganisationId(

--- a/tests/unit/test_seps_write_unit.py
+++ b/tests/unit/test_seps_write_unit.py
@@ -21,6 +21,7 @@ from pyetnic.services.models import (
     SepsNaissanceSave,
     SepsUESave,
 )
+from pyetnic.services.seps import SepsAuthError, SepsEtnicError
 
 
 @pytest.fixture(autouse=True)
@@ -99,6 +100,58 @@ class TestEnregistrerEtudiantPayload:
         assert payload["naissance"] == {"date": "1990", "codePays": "150"}
         for absent in ("niss", "prenom", "sexe", "adresse", "deces"):
             assert absent not in payload
+
+
+class TestEnregistrerEtudiantErrors:
+    """A success=False response must raise a typed error, never return None silently."""
+
+    def test_enregistrer_raises_on_business_error(self, monkeypatch):
+        service = EnregistrerEtudiantService()
+
+        def fake_call(method_name, **kwargs):
+            return {
+                "body": {
+                    "success": False,
+                    "messages": {
+                        "error": [
+                            {"code": "30201", "description": "Étudiant déjà existant"},
+                        ],
+                    },
+                },
+            }
+
+        monkeypatch.setattr(service.client_manager, "call_service", fake_call)
+
+        with pytest.raises(SepsEtnicError) as exc_info:
+            service.enregistrer_etudiant(
+                mode_enregistrement="NISS",
+                etudiant_details=EtudiantDetailsSave(niss="12345678901"),
+            )
+        assert exc_info.value.code == "30201"
+
+    def test_modifier_raises_on_auth_error(self, monkeypatch):
+        service = EnregistrerEtudiantService()
+
+        def fake_call(method_name, **kwargs):
+            return {
+                "body": {
+                    "success": False,
+                    "messages": {
+                        "error": [
+                            {"code": "30550", "description": "Certificat invalide"},
+                        ],
+                    },
+                },
+            }
+
+        monkeypatch.setattr(service.client_manager, "call_service", fake_call)
+
+        with pytest.raises(SepsAuthError) as exc_info:
+            service.modifier_etudiant(
+                cf_num="123-01",
+                etudiant_details=EtudiantDetailsSave(nom="DUPONT"),
+            )
+        assert exc_info.value.code == "30550"
 
 
 class TestInscriptionsPayload:

--- a/tests/unit/test_seps_write_unit.py
+++ b/tests/unit/test_seps_write_unit.py
@@ -19,6 +19,7 @@ from pyetnic.services.models import (
     InscriptionInputDataSave,
     InscriptionInputSave,
     SepsNaissanceSave,
+    SepsSpecificiteSave,
     SepsUESave,
 )
 from pyetnic.services.seps import SepsAuthError, SepsEtnicError
@@ -196,6 +197,35 @@ class TestInscriptionsPayload:
         assert inscription["ue"] == {"noAdministratif": 328, "noOrganisation": 1}
         for absent in ("anneeScolaire", "specificite"):
             assert absent not in inscription, f"expected {absent!r} to be stripped"
+
+    def test_specificite_regulier_fields_serialized(self, monkeypatch):
+        """regulier1/regulier5 belong to the input contract (SpecificiteDataType)
+        and must be serialized when set, stripped when None."""
+        service = InscriptionsService()
+        captured: dict = {}
+
+        def fake_call(method_name, **kwargs):
+            captured["kwargs"] = kwargs
+            return {"body": {"success": True, "response": {"inscription": {"cfNum": "123-01"}}}}
+
+        monkeypatch.setattr(service._enregistrer, "call_service", fake_call)
+
+        data = InscriptionInputDataSave(
+            cfNum="123-01",
+            idEtab=3052,
+            idImplantation=6050,
+            codePostalLieuCours="1000",
+            inscription=InscriptionInputSave(
+                dateInscription="2024-09-01",
+                statut="DE",
+                ue=SepsUESave(noAdministratif=328, noOrganisation=1),
+                specificite=SepsSpecificiteSave(regulier1="O", regulier5="N"),
+            ),
+        )
+        service.enregistrer_inscription(inscription_input_data=data)
+
+        specificite = captured["kwargs"]["inscriptionInputData"]["inscription"]["specificite"]
+        assert specificite == {"regulier1": "O", "regulier5": "N"}
 
     def test_modifier_inscription_payload_excludes_none(self, monkeypatch):
         service = InscriptionsService()


### PR DESCRIPTION
Post-`0.1.0b1` maintenance round driven by a multi-agent audit confronting the
session-7 enriched `specs/` (full SEPS family + circulaires + INS referentials)
against the code. **283 tests green** (was 230).

## Base (already committed on the audit-coherence branch, never PR'd)
- `fix(soap)`: tolerate unknown response elements via zeep `strict=False` (SEPS prod responses)
- `feat(examples)`: Doc 1 vs SEPS inscription coherence audit script (+ refinement)

## SEPS quick-wins
- **Stop swallowing server errors as `None`** — `lire_etudiant`/`enregistrer_etudiant`/`modifier_etudiant`
  now raise typed SEPS exceptions via a shared `_check_seps_errors` (NOT_FOUND 30110/30115 still → `None`/`[]`)
- **`autrePrenom` no longer char-split** — `_as_list` treats `str`/`bytes` as scalar

## Four known latent bugs (all closed)
1. `formations_liste` messagesType → flat `List[str]` (`_flatten_messages`)
2. `creer/modifier_organisation` no longer serialize `None` (empty-tag "erase" risk)
3. `Doc2ActiviteEnseignementLine` field order realigned to the XSD (coEtuReg last, no `=0` defaults)
4. `extract_error_info` falls back to the Common_v2 `body['requestId']` attribute
   — non-regressive, still unconfirmed against a live v7 error response

## Nomenclatures (option 2)
- 12 inscription enums pinned against `inscription_v1.xsd`, exported from `pyetnic.seps`
  (CodeStatut, Indicateur, IndicateurX, MotifExemption, MotifExemptionSpec, TypeEnseignement,
  TitreDelivre×23, Equivalence, ValorisationAcquis, ValorisationAcquisSanction, StatutFinFormation, CodeNiveau)
- `SepsSpecificiteSave`: added `regulier1`/`regulier5` (input is `SpecificiteDataType`, not the dead `SpecificiteDataInputType`)

## Docs
PUBLIC_API_SURFACE, CHANGELOG `[Unreleased]`, and plan.md updated.

Backlog (not in this PR): SEPS Notifications + Document 1D services, SEPS error-code
hierarchy decision, INS referential wiring.

🤖 Generated with [Claude Code](https://claude.com/claude-code)