### PR TITLE
docs: specs 16-21, doc3 referential report, 2026-2027 production tests and scope boundary

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -15,6 +15,38 @@ config → soap_client → services → public namespaces (eprom, seps)
 - `services/` — internal service classes + dataclasses (`models.py`). Not imported directly.
 - `eprom/`, `seps/` — public namespaces re-exporting the stable API.
 
+## Scope Boundary
+
+pyetnic is a **contract-fidelity layer**, not a business layer. It accumulates business
+*knowledge* in its documentation (`specs/`, `docs/SPEC.md`) but must not implement business
+*logic* in its code. Decision recorded 2026-06-11 after the first full-scale production tests.
+
+**Litmus test:** pyetnic code changes only when the ETNIC *contract* changes (WSDL, XSD,
+error codes, nomenclatures). If a *circulaire* changes and pyetnic must change, the business
+logic landed in the wrong place.
+
+In scope (contract fidelity):
+
+- Typed models mirroring the XSD contracts (including the Read/Save split).
+- The typed exception hierarchy mapping ETNIC error codes (e.g. `20030`, `20028`) — error
+  codes are part of the wire protocol, not policy.
+- Nomenclature enums (wire-level value sets).
+- Wire-safety transforms (`None`-stripping, D2) and request-shape gotchas (`implId`, D5).
+- Documenting server-side business rules in docstrings and `specs/` (e.g. the 4-month
+  anticipation limit, the two-school-year organisation linking semantics).
+
+Out of scope (belongs to applications built on top, e.g. a school-management Django app):
+
+- **Client-side pre-validation duplicating server rules** (e.g. rejecting a start date
+  beyond 4 months before calling). Rules change by circulaire; the server is the authority.
+  pyetnic surfaces the server's verdict as a typed exception instead of predicting it.
+- **Workflow orchestration** (e.g. deciding which organisations to open from an inspector
+  schedule, locating the head of a two-school-year UE and copying its dates).
+- **Derived computations** the services do not expose (dixièmes, dotation/encadrement —
+  spec 21 is reference material for consumers, not for this library).
+- **Convenience helpers that decide**: helpers may compose reads and fill wire-level
+  requirements, never encode policy thresholds or fabricate decisions.
+
 ## Key Decisions
 
 ### Lazy Config via metaclass (Sprint 0)

--- a/docs/AUDIT.md
+++ b/docs/AUDIT.md
@@ -280,3 +280,56 @@ The two highest-leverage fixes:
 2. **Replace `asdict()` with None-stripping serialization (D2)**: eliminates a whole class of silent bugs on partial updates.
 
 The decision to migrate to Pydantic v2 is a heavier one, to be evaluated separately — it brings much (validation, clean serialization, JSON schema) but requires touching all models and reconverging tests. Keeping dataclasses with a `to_soap_dict(exclude_none=True)` helper captures 80% of the benefit for 20% of the effort.
+
+---
+
+## Addendum — post-0.0.12 empirical findings
+
+> The body above (D1–D6, Q1–Q10, H1–H11) is the immutable 0.0.12 snapshot.
+> Findings below were added later from runtime observation and are dated
+> individually. They continue the defect numbering so they stay referenceable.
+
+### D7 — Doc3 `nbPeriodes*` models typed `float` while the XSD declares `xs:int`
+
+> **Date**: 2026-06-10 · **Provenance**: read-only referential audit of
+> `LireDocument3` (see `rapport_referentiels_doc3.md`). · **Severity**: latent
+> (typing/correctness), no active impact on current data.
+
+In `services/models.py`, `Doc3ActiviteDetail` declares the three period counters
+as floats:
+
+```python
+nbPeriodesDoc8: Optional[float] = None
+nbPeriodesPrevuesDoc2: Optional[float] = None
+nbPeriodesReellesDoc2: Optional[float] = None
+```
+
+But `resources/EPROM_Document_3_1.0/xsd/FormationDocument3_v1.xsd` declares all
+three as **`xs:int`**. zeep deserializes against the (embedded) XSD, i.e. via
+`int(text)` — so the `float` annotation never takes effect. The practical
+consequences:
+
+- If ETNIC ever serialized a decimal (the suspected `"24.0"`) on one of these
+  elements, **zeep would raise `ValueError: invalid literal for int()` inside
+  `call_service` — before** any pyetnic dataclass is constructed. The `float`
+  type, presumably added to tolerate decimals, is therefore **inert**: it can
+  never catch a decimal because zeep rejects it upstream.
+- `nbPeriodesAttribuees` is correctly `float` ↔ `xs:float`; only the three
+  counters above are mismatched. (`coNumBranche`, `coNumAttribution` are
+  correctly `int` ↔ `xs:int`.)
+
+**Empirical check (2026-06-10)**: a read-only sweep of `LireDocument3` over all
+**123 organisations** of `etabId=3052` / `2024-2025` on TQ (765 attributions)
+found **zero** non-integer values on these `xs:int` fields and zeep raised **no**
+`ValueError`. Current data is clean ⇒ no live impact. This is a latent
+typing/correctness defect, not an active bug.
+
+**Fix** — decide the source of truth:
+- If ETNIC truly emits integers → align the models to `Optional[int]` (remove the
+  misleading `float`).
+- If decimals are genuinely expected → the **embedded** XSD is wrong and should be
+  `xs:float`/`xs:decimal`. Note that zeep validates against the *embedded* copy,
+  not the live ETNIC schema, so the embedded file governs parsing regardless of
+  what ETNIC publishes.
+
+Until arbitrated, treat the `float` annotation on these three fields as decorative.

--- a/rapport_referentiels_doc3.md
+++ b/rapport_referentiels_doc3.md
@@ -1,0 +1,126 @@
+# Rapport — référentiels EPROM Document 3 (lecture seule)
+
+> Audit **strictement en lecture seule** : seuls `ListerFormations` et `LireDocument3` (SOAP 1.1) ont été appelés. Aucune opération Creer/Modifier/Supprimer/Approuver.
+
+## Contexte d'exécution
+
+| Paramètre | Valeur |
+| --- | --- |
+| Environnement (`Config.ENV`) | `dev` → endpoints **TQ** (qualification) |
+| Endpoint Doc3 | `https://services-web.tq.etnic.be:11443/eprom/formation/document3/v1` |
+| Binding SOAP | `EPROMFormationDocument3ExternalV1Binding` — `soap:binding` (**SOAP 1.1**) |
+| Année scolaire | 2024-2025 |
+| etabId | 3052 |
+| implId | 6050 |
+| Formations retournées | 110 |
+| Organisations totales | 123 |
+| Organisations interrogées | 123 — plafond consigne 30 **relevé volontairement** à l'ensemble (volume modéré, lecture seule, meilleure couverture des référentiels) |
+| Doc3 lus avec succès | 123 |
+| zeep | 4.3.2 |
+
+## a. Valeurs distinctes de `teStatut`
+
+> ⚠ **Important** : la réponse `LireDocument3` ne transporte que le **code** `teStatut`, jamais son libellé. Observer une lettre **prouve seulement que le code existe** dans les données ; elle ne **confirme pas** la correspondance code→libellé de l'hypothèse, qui doit être recoupée dans l'UI EPROM.
+
+| teStatut | Occurrences | Libellé supposé (hypothèse, non vérifiable via Doc3) | Constat brut |
+| --- | --- | --- | --- |
+| *(vide)* | 441 | — | *(élément présent mais vide)* |
+| `T` | 231 | Temporaire | code observé |
+| `E` | 53 | Expert | code observé |
+| `D` | 40 | Définitif | code observé |
+
+> Codes de l'hypothèse **jamais rencontrés** sur l'ensemble (etabId=3052, 2024-2025) : `A`, `C`, `P`, `X` — ni confirmés, ni infirmés.
+
+## b. Valeurs distinctes de `coDispo`
+
+> Même réserve que pour `teStatut` : seul le **code** `coDispo` est renvoyé, sans libellé. La table atteste l'existence des codes, pas leur signification.
+
+| coDispo | Occurrences | Constat brut |
+| --- | --- | --- |
+| *(vide)* | 655 | *(élément présent mais vide)* |
+| `15` | 104 | code observé |
+| `05` | 5 | code observé |
+| `28` | 1 | code observé |
+
+## c. Détail formation numAdmFormation=157, numOrganisation=1
+
+> Champs enseignant identifiants masqués par `***` (`noMatEns`, `teNomEns`, `tePrenomEns`, `teEnseignant` — requis ; `teAbrEns`, `teUserMaj` masqués en plus par prudence PII).
+
+### Activité 1
+
+| coNumBranche | coCategorie | teNomBranche | noAnneeEtude | nbPeriodesDoc8 | nbPeriodesPrevuesDoc2 | nbPeriodesReellesDoc2 |
+| --- | --- | --- | --- | --- | --- | --- |
+| 1 | CTms | METHODES DE TRAVAIL | 1 | 48 | 20 | 20 |
+
+| coNumAttribution | coDispo | teStatut | nbPeriodesAttribuees |
+| --- | --- | --- | --- |
+| 1 |  | T | 20.0 |
+
+## d. XML brut LireDocument3 — formation 157/org 1 (anonymisé)
+
+```xml
+<soapenv:Envelope xmlns:msg="http://services-web.etnic.be/eprom/formation/document3/messages/v1" xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/" xmlns:soapenv12="http://www.w3.org/2003/05/soap-envelope" xmlns:status="http://etnic.be/types/technical/ResponseStatus/v3">
+   <Header xmlns="http://schemas.xmlsoap.org/soap/envelope/">
+	<requestId xmlns="http://etnic.be/types/technical/requestId/v1">39156860-4353-46fc-bacb-12dfd00f9567</requestId>
+</Header><soapenv:Body>
+      <LireDocument3Reponse xmlns="http://services-web.etnic.be/eprom/formation/document3/messages/v1">
+         <success xmlns="http://etnic.be/types/technical/ResponseStatus/v3">true</success>
+         <response>
+            <p784:document3 xmlns:p784="http://enseignement.cfwb.be/types/formation/document3/v1">
+               <p784:id>
+                  <p752:anneeScolaire xmlns:p752="http://enseignement.cfwb.be/types/organisation/v1">2024-2025</p752:anneeScolaire>
+                  <p752:etabId xmlns:p752="http://enseignement.cfwb.be/types/organisation/v1">3052</p752:etabId>
+                  <p752:implId xmlns:p752="http://enseignement.cfwb.be/types/organisation/v1">6050</p752:implId>
+                  <p752:numAdmFormation xmlns:p752="http://enseignement.cfwb.be/types/organisation/v1">157</p752:numAdmFormation>
+                  <p752:numOrganisation xmlns:p752="http://enseignement.cfwb.be/types/organisation/v1">1</p752:numOrganisation>
+               </p784:id>
+               <p784:activiteListe>
+                  <p784:activite>
+                     <p784:coNumBranche>1</p784:coNumBranche>
+                     <p784:coCategorie>CTms</p784:coCategorie>
+                     <p784:teNomBranche>METHODES DE TRAVAIL</p784:teNomBranche>
+                     <p784:noAnneeEtude>1</p784:noAnneeEtude>
+                     <p784:nbPeriodesDoc8>48</p784:nbPeriodesDoc8>
+                     <p784:nbPeriodesPrevuesDoc2>20</p784:nbPeriodesPrevuesDoc2>
+                     <p784:nbPeriodesReellesDoc2>20</p784:nbPeriodesReellesDoc2>
+                     <p784:enseignantListe>
+                        <p784:enseignant>
+                           <p784:coNumAttribution>1</p784:coNumAttribution>
+                           <p784:noMatEns>***</p784:noMatEns>
+                           <p784:teNomEns>***</p784:teNomEns>
+                           <p784:tePrenomEns>***</p784:tePrenomEns>
+                           <p784:teAbrEns>***</p784:teAbrEns>
+                           <p784:teEnseignant>***</p784:teEnseignant>
+                           <p784:coDispo/>
+                           <p784:teStatut>T</p784:teStatut>
+                           <p784:nbPeriodesAttribuees>20.0</p784:nbPeriodesAttribuees>
+                           <p784:tsMaj>2026-05-31 17:22:16.694441</p784:tsMaj>
+                           <p784:teUserMaj>***</p784:teUserMaj>
+                        </p784:enseignant>
+                     </p784:enseignantListe>
+                  </p784:activite>
+               </p784:activiteListe>
+            </p784:document3>
+         </response>
+      </LireDocument3Reponse>
+   </soapenv:Body>
+</soapenv:Envelope>
+```
+
+### Sérialisation des champs numériques
+
+Types XSD côté réponse (`FormationDocument3_v1.xsd`) : `coNumBranche`, `coNumAttribution`, `nbPeriodesDoc8`, `nbPeriodesPrevuesDoc2`, `nbPeriodesReellesDoc2` = **`xs:int`** ; `nbPeriodesAttribuees` = `xs:float`.
+
+✓ Aucun champ `xs:int` ne porte de valeur à virgule sur l'ensemble des 123 organisations (765 attributions) : pas de « 24.0 » observé. Le seul `.0` rencontré est sur `nbPeriodesAttribuees` (`xs:float`, ex. `20.0`) — sérialisation **correcte**.
+
+> **Désaccord de type latent à signaler** : le modèle pyetnic déclare `nbPeriodesDoc8`, `nbPeriodesPrevuesDoc2`, `nbPeriodesReellesDoc2` en `Optional[float]` (`services/models.py`), alors que le XSD les déclare en `xs:int`. zeep désérialise selon le XSD (`int`) : si ETNIC renvoyait un jour « 24.0 » sur ces champs, **zeep lèverait `ValueError` AVANT** que le type `float` du modèle ne serve à quoi que ce soit. Le type `float` du modèle est donc actuellement **inopérant** (masqué par le parsing `xs:int` de zeep). Données actuellement propres → aucun impact, mais à arbitrer : soit aligner le modèle sur `int`, soit (si ETNIC envoie réellement des décimales) corriger le XSD embarqué en `xs:float`/`xs:decimal`.
+
+### ValueError / warnings zeep (parsing typé)
+
+✓ Aucun `ValueError` levé par zeep sur l'échantillon interrogé.
+
+## e. Codes d'erreur rencontrés (service, code, libellé)
+
+*Aucune erreur rencontrée.*
+
+

--- a/rapport_test_prod_organisation_328.md
+++ b/rapport_test_prod_organisation_328.md
@@ -1,0 +1,183 @@
+# Test grandeur nature en production — ouverture organisation F328 (2026-2027)
+
+**Date du test :** 2026-06-11
+**Environnement :** production (`ENV=prod`, services-web.etnic.be)
+**Compte :** ec003052@adm.cfwb.be — établissement 3052, implantation 6050
+**Objectif :** ouvrir une organisation de la formation 328 sur l'année scolaire 2026-2027, du 15/09/2026 au 13/10/2026, et valider le comportement de `pyetnic.eprom` en conditions réelles.
+
+## Déroulement
+
+### 1. `lister_formations_organisables(annee_scolaire="2026-2027")` — OK
+
+- 110 formations organisables retournées pour 2026-2027.
+- Formation 328 présente : `INFORMATIQUE : INTRODUCTION A L'INFORMATIQUE`, code `750102U21D1`, `organisations=[]` (aucune organisation existante).
+
+### 2. `creer_organisation(...)` — OK
+
+Appel minimal (uniquement les champs obligatoires, tous les booléens optionnels à `None`) :
+
+```python
+eprom.creer_organisation(
+    annee_scolaire="2026-2027",
+    etab_id=3052,
+    impl_id=6050,
+    num_adm_formation=328,
+    date_debut=date(2026, 9, 15),
+    date_fin=date(2026, 10, 13),
+)
+```
+
+Réponse serveur :
+
+- `numOrganisation=1` attribué par le serveur et correctement reconstruit dans l'`OrganisationId` retourné (parsing de la réponse `CreerOrganisation` sans id fourni — OK).
+- `nombreSemaineFormation=4` calculé côté ETNIC (15/09 → 13/10 = 4 semaines).
+- Statut : `Encodé école`, daté du 2026-06-11.
+
+### 3. `lire_organisation(...)` — relecture OK
+
+Relecture avec l'id complet (`implId=6050`) : données identiques à la création.
+Valeurs par défaut appliquées côté serveur pour les champs optionnels omis :
+
+- Tous les booléens (`organisationPeriodesSupplOuEPT`, `valorisationAcquis`, `enPrison`, `eLearning`, `reorientation7TP`, `activiteFormation`, `conseillerPrevention`, `partiellementDistance`, `enseignementHybride`, `interventionExterieure50p`) → `False`
+- `numOrganisation2AnneesScolaires` → `0`
+- `typeInterventionExterieure` → `None`
+- Statuts Doc 1/2/3 (`statutDocumentPopulationPeriodes`, `statutDocumentDroitsInscription`, `statutDocumentAttributions`) → `None` (cohérent avec SPEC : statut « Encodé école » ⇒ Doc 1/2/3 pas encore accessibles)
+
+### 4. `lister_formations(annee_scolaire="2026-2027")` — OK
+
+La nouvelle organisation apparaît dans l'aperçu de la formation 328.
+**Confirmation du gotcha implId** : dans l'`OrganisationApercu` retourné par `ListerFormations`, `implId=None` alors que l'organisation a bien été créée sur l'implantation 6050. L'implId doit donc être réinjecté par l'appelant pour les appels suivants (comportement déjà documenté dans `docs/SPEC.md`).
+
+## Points de développement confirmés
+
+| Point | Verdict |
+|---|---|
+| Strip des champs `None` à la création (défaut D2 : élément XML vide = « effacer ») | ✅ Aucune erreur, défauts serveur propres (`False`/`0`) |
+| Reconstruction de l'id depuis la réponse `CreerOrganisation` (numOrganisation serveur) | ✅ |
+| `strict_errors()` sur le chemin nominal (aucune exception parasite) | ✅ |
+| Format année scolaire `AAAA-AAAA` | ✅ |
+| Gotcha `implId=None` dans les aperçus de `ListerFormations` | ✅ Reproduit en prod |
+| Calcul serveur de `nombreSemaineFormation` | ✅ (4 semaines) |
+
+## État final en production
+
+Organisation **conservée** (objectif réel d'ouverture, pas un test jetable) :
+
+- `anneeScolaire=2026-2027`, `etabId=3052`, `implId=6050`, `numAdmFormation=328`, `numOrganisation=1`
+- Du 2026-09-15 au 2026-10-13, statut « Encodé école »
+
+Prochaine étape possible : encodage Doc 1 (population) une fois l'organisation validée côté administration.
+
+---
+
+# Test 2 — ouvertures depuis l'horaire inspecteur « Bureautique Soir 2026-2027 » (échec attendu, règle 20030)
+
+**Date du test :** 2026-06-11
+
+Source : PDF « Horaire inspecteur — Bureautique Soir — 2026-2027 ». Ouvertures déduites :
+
+| N° adm | Code UF | Libellé | Début | Fin |
+|---|---|---|---|---|
+| 406 | 754501U21D2 | INFORMATIQUE : TABLEUR - NIVEAU ÉLÉMENTAIRE | 03/11/2026 | 20/04/2027 |
+| 405 | 754201U21D2 | INFORMATIQUE : ÉDITION ASSISTÉE PAR ORDINATEUR - NIV. ÉLÉMENTAIRE | 03/11/2026 | 20/04/2027 |
+
+## Observations
+
+1. **Concordance référentiel** : les deux `numAdmFormation` (405, 406) et codes UF du PDF correspondent
+   exactement à `ListerFormationsOrganisables` 2026-2027. Aucune organisation préexistante.
+2. **Refus métier `20030`** : `CreerOrganisation` avec début au 03/11/2026 rejeté —
+   « La date de début d'organisation ne peut excéder un délai de 4 mois maximum ».
+   - Levée proprement en `EtnicValidationError` sous `strict_errors()` (hiérarchie d'exceptions ✅).
+   - La règle (spec `02_formation_organisation_v7.md` §codes erreur) est confirmée en prod : le délai
+     s'applique aux dates de début **futures**. Point de mesure : J+3 mois 4 j accepté (test 1,
+     15/09/2026), J+4 mois 22 j rejeté. Borne probable : J+4 mois calendaires (→ pour un début au
+     03/11/2026, création possible à partir du **03/07/2026**).
+3. **Atomicité** : échec sur la première création (406) → aucun résidu en prod, vérifié par relecture
+   (405 et 406 toujours sans organisation, la 328 du test 1 intacte).
+
+## État final
+
+Aucune création. **À refaire à partir du 03/07/2026** : ouvrir 406 et 405, 2026-2027,
+du 03/11/2026 au 20/04/2027, étab 3052 / impl 6050.
+
+---
+
+# Test 3 — ouverture depuis l'horaire inspecteur « Technique Soir 2026-2027 »
+
+**Date du test :** 2026-06-11
+
+Source : PDF « Horaire inspecteur — Technique Soir — 2026-2027 ». Deux candidates :
+
+| N° adm | Code UF | Libellé | Début | Fin | Mention PDF |
+|---|---|---|---|---|---|
+| 537 | 752247U21D1 | PROGRAMMATION : NIVEAU 1 | 14/09/2026 | 21/06/2027 | Organisation1 |
+| 511 | 750402U21D2 | INFORMATIQUE : MAINTENANCE SOFTWARE | 17/09/2026 | 03/06/2027 | **Organisation2** |
+
+Décision utilisateur : ouvrir **uniquement la 537** (ambiguïté « Organisation2 » sur la 511 :
+aucune organisation n'existe côté ETNIC pour cette formation, alors que le PDF numérote 2 —
+le numOrganisation étant attribué par le serveur, une création aurait produit un n°1 discordant).
+
+## Observations
+
+1. Débuts à ~J+3 mois : règle `20030` non déclenchée, comme prédit (cohérent avec la borne
+   mesurée au test 2).
+2. **Création 537 OK** : `numOrganisation=1`, `nombreSemaineFormation=40` calculé serveur
+   (14/09/2026 → 21/06/2027), statut « Encodé école » au 2026-06-11. Relecture conforme.
+3. **Dixièmes absents du modèle SOAP** : le PDF inspecteur affiche « Premier dixième » et
+   « Cinquième dixième » (12/10/2026 et 01/02/2027 pour la 537), mais l'objet `Organisation`
+   ETNIC n'expose aucun champ dixième. Ces dates sont donc calculées ailleurs (UI EPROM ?
+   à partir des périodes du Doc 2 ?) — point à creuser pour les specs.
+
+## État final
+
+- 537/1 ouverte : 2026-2027, 14/09/2026 → 21/06/2027, étab 3052 / impl 6050, « Encodé école ».
+- 511 **non ouverte** : à clarifier (pourquoi « Organisation2 » sur le PDF ?) avant création.
+
+---
+
+# Test 4 — recherche de l'UE sur 2 années scolaires se terminant en 2026-2027 (lecture seule)
+
+**Date du test :** 2026-06-11
+
+Contexte : la 511 n'a pas été ouverte (UE liée à une UE sur deux années scolaires se terminant
+en 26-27). Recherche par balayage de toutes les organisations 2025-2026 de l'établissement.
+
+## Résultat
+
+Une seule organisation 2025-2026 se termine dans l'année scolaire 2026-2027 :
+
+- **UE 510 — INFORMATIQUE : MAINTENANCE HARDWARE (750401U21D3), organisation 3** :
+  09/03/2026 → 29/01/2027, 40 semaines, statut « Approuvé », `numOrganisation2AnneesScolaires = 0`.
+
+C'est donc la tête du couple : son prolongement 2026-2027 devra être créé avec **les mêmes dates
+complètes** (09/03/2026 → 29/01/2027) et `numOrganisation2AnneesScolaires = 3`.
+
+## Sémantique du lien 2 années scolaires (confirmée sur le couple 511 de 2024-2025/2025-2026)
+
+- Un enregistrement d'organisation **par année scolaire**, chacun portant les **dates complètes**
+  de l'UE (la date de début/fin peut donc tomber hors de l'année scolaire de l'enregistrement).
+- Tête (1re année) : `numOrganisation2AnneesScolaires = 0`.
+- Queue (2e année) : `numOrganisation2AnneesScolaires` = `numOrganisation` de la tête.
+- Exemple réel : 511 org 4 (2024-2025) et 511 org 2 (2025-2026), toutes deux 22/05/2025 →
+  30/01/2026, la seconde pointant vers 4. Code erreur associé : `20028` (numéro année précédente
+  incorrect). Sémantique ajoutée à `specs/02_formation_organisation_v7.md`.
+
+## Création de la queue 2026-2027 de la 510 (confirmée, exécutée le 11/06/2026)
+
+`CreerOrganisation` : 2026-2027, étab 3052 / impl 6050, formation 510,
+09/03/2026 → 29/01/2027, `numOrganisation2AnneesScolaires=3` → **succès**.
+
+- `numOrganisation=1` attribué, 40 semaines (identique à la tête 2025-2026), statut
+  « Encodé école » au 11/06/2026.
+- Relecture conforme : dates complètes et `numOrganisation2AnneesScolaires=3` persistés.
+- **Règle `20030` non déclenchée avec une date de début passée** (09/03/2026 = J−3 mois) :
+  confirmation qu'elle ne borne que l'anticipation, pas le rétroactif (complète le point
+  de spec 19).
+- Le serveur accepte une `dateDebutOrganisation` hors de l'année scolaire de l'enregistrement
+  (09/03/2026 ∈ 2025-2026 pour un enregistrement 2026-2027) dès lors que le lien 2 années
+  est renseigné — cohérent avec la sémantique « dates complètes sur les deux enregistrements ».
+
+## Reste à faire
+
+- La 511 du PDF (« Organisation2 », 17/09/2026 → 03/06/2027) reste à ouvrir ; son
+  numéro sera attribué par le serveur.

--- a/specs/02_formation_organisation_v7.md
+++ b/specs/02_formation_organisation_v7.md
@@ -121,6 +121,14 @@ ResponseType (abstract, extends ResponseAttributesType)
 
 > **Règle métier** : `implId` est **obligatoire** dans CreerOrganisation (contrairement à Lire/Modifier/Supprimer où il est absent du bloc id de la requête).
 
+> **Sémantique observée en production (11/06/2026, étab 3052)** — UE sur 2 années scolaires :
+> chaque année porte son propre enregistrement d'organisation, et **les deux portent les dates
+> complètes** de l'UE (y compris la portion hors de leur année scolaire). L'enregistrement de la
+> **première** année a `numOrganisation2AnneesScolaires = 0` ; celui de la **seconde** année pointe
+> vers le `numOrganisation` de la première. Exemple réel : UE 511, org 4 de 2024-2025 et org 2 de
+> 2025-2026 portent toutes deux 22/05/2025 → 30/01/2026, la seconde avec
+> `numOrganisation2AnneesScolaires = 4`.
+
 ### Réponse
 
 **Type** : `CreerOrganisationReponseCT` extends `ResponseType`

--- a/specs/16_circulaires_droit_inscription.md
+++ b/specs/16_circulaires_droit_inscription.md
@@ -1,0 +1,152 @@
+# Circulaires « Droit d'inscription » (DI) — règles métier pour Doc 1D (EPROM) et Inscription (SEPS)
+
+> Spécification fonctionnelle issue des circulaires annuelles « Dispositions applicables en matière de
+> droit d'inscription dans l'Enseignement de promotion sociale / pour Adultes ».
+> Sources : **9217 du 03/04/2024** (texte intégral, via miroir ICC Bruxelles), **9488 du 16/04/2025**
+> (montants via synthèse établissement GHA-WBE), **9731 du 27/05/2026** (métadonnées Gallilex ; PDF à analyser).
+> Date d'analyse : 2026-06-10 (session 8)
+
+---
+
+## 1. Chaîne d'abrogation (circulaire annuelle)
+
+| Circulaire | Date | Année concernée | Statut | Gallilex |
+|---|---|---|---|---|
+| 8914 | 28/04/2023 | 2023-2024 | abrogée par 9217 | — |
+| **9217** | 03/04/2024 | 2024-2025 | abrogée par 9488 | doc 51?? — texte intégral récupéré ([miroir ICC](https://www.iccbxl.be/web/data/uploads/pdf/circulaire-9217-di-24-25.pdf)) |
+| **9488** | 16/04/2025 | 2025-2026 | abrogée par 9731 | [doc 52388](https://gallilex.cfwb.be/circulaires/52388) |
+| **9731** | 27/05/2026 | **2026-2027** (validité 24/08/2026) | **en vigueur** | [doc 53231](https://gallilex.cfwb.be/circulaires/53231) — **texte intégral : `circulaires/53231_0000.pdf`** |
+
+> Gestionnaire : AGE-DGESVR, Direction de l'Enseignement pour Adultes, **Service de la Vérification**
+> (C. Simons et al.) — le même service qui gère la circulaire 8684 « Renseignements annuels ».
+> ⚠️ Le **mécanisme** (formule, assiette, plafond, exonérations) est stable d'année en année ; seuls les
+> **montants indexés** changent. La structure ci-dessous suit la 9217 ; montants 2025-2026 d'après la 9488.
+
+## 2. Formule de calcul du DI
+
+```
+DI = forfait (1×/année scolaire) + tarif_niveau × min(périodes, 800)
+```
+
+Indexation : `DI(2015+N) = DI(2015) × IPC(01/2015+N) / IPC(01/2015)` (indice des prix à la consommation).
+
+| Montant | 2024-2025 (9217) | 2025-2026 (9488) | 2026-2027 (9731) |
+|---|---|---|---|
+| Forfait annuel (sec. + sup.) | 32 € | 33 € | **34 €** |
+| Tarif/période — secondaire | 0,28 € | 0,29 € | **0,30 €** |
+| Tarif/période — supérieur | 0,45 € | *non repris dans la synthèse GHA — à confirmer (≈0,46 €)* | **0,47 €** |
+| Plafond de périodes payantes | 800 | 800 | **800** |
+
+> Exemples normatifs 9731 (mêmes cas que la 9217, montants 2026-2027) : 120 p. sec → 70 € ;
+> 860 p. sec → 274 € ; 500 sec + 400 sup → 34 + 500×0,30 + 300×0,47 = **325 €** ; remboursement
+> multi-étab. : 410 € → 376 € → B rembourse **34 €**. La mécanique est inchangée.
+
+### Règles d'assiette (stables)
+
+1. **Assiette = totalité des périodes prévues au dossier pédagogique** des UE auxquelles l'étudiant
+   s'inscrit — « donnant lieu à une rémunération de chargé de cours », **y compris les périodes
+   d'encadrement** (stage, épreuve intégrée), de 50 minutes — *que la totalité soit enseignée ou non
+   durant l'année*. → côté services : c'est le nombre de périodes du **dossier pédagogique** (cf. Doc 8/8bis,
+   `nbPeriodesDoc8`), pas les périodes réellement organisées (Doc 2).
+2. **Rattachement à l'année** : une UE compte pour l'année académique dans laquelle se situe son
+   **premier dixième** (règle du 1/10ᵉ — même pivot que `regulier1` SEPS).
+3. **Plafond 800 périodes** : au-delà, périodes gratuites. En cas de mixte secondaire/supérieur, on
+   compte **d'abord les périodes du secondaire**, puis le solde du plafond au tarif supérieur
+   (ex. 9217 : 500 sec + 400 sup → 32 + 500×0,28 + **300**×0,45 = 307 €).
+4. **Forfait unique par année scolaire**, y compris multi-établissements.
+5. **Moment du paiement** : avant le **1ᵉʳ dixième** de l'UE/section (condition de régularité de
+   l'étudiant). *(La formulation « au moment de l'inscription » de la synthèse GHA est une pratique
+   d'établissement, pas la règle de la circulaire.)*
+
+### Exemples normatifs (9217, montants 2024-2025)
+
+| Cas | Calcul | DI |
+|---|---|---|
+| 120 p. secondaire | 32 + 120×0,28 | 65,60 € |
+| 860 p. secondaire | 32 + 800×0,28 | 256 € |
+| 240 p. sec + 10 p. encadr. stage + 4 p. encadr. épreuve intégrée | 32 + 254×0,28 | 103,12 € |
+| 120 p. sec + 10 p. sup | 32 + 120×0,28 + 10×0,45 | 70,10 € |
+| 500 p. sec + 400 p. sup | 32 + 500×0,28 + 300×0,45 | 307 € |
+| Remboursement : étab. A 900 p. sup (392 €) puis étab. B 200 p. sec | recalcul global 32 + 200×0,28 + 600×0,45 = 358 € → **B rembourse 34 €** | |
+
+> ⭐ **Implication client** : le DI est **recalculé globalement** à chaque nouvelle inscription dans
+> l'année (multi-établissements compris), avec obligation de remboursement par le 2ᵉ établissement.
+> Un helper pyetnic de calcul/contrôle du DI doit donc prendre en entrée *toutes* les inscriptions de
+> l'année de l'étudiant, pas seulement celle en cours.
+
+## 3. Exonérations (art. 12 §3 de la loi du 29/05/1959 « Pacte scolaire »)
+
+Liste 9217/9488 (stable) — rapprochement avec l'énumération SEPS `MotifExemptionType` (C01-C07,
+spec 11 / registre §7.5) :
+
+| Condition d'exonération (circulaire) | Code SEPS probable |
+|---|---|
+| Mineurs soumis à l'obligation scolaire | C01 (mineur) |
+| Chômeurs complets indemnisés ; travailleurs temps partiel avec AGR | C02 (chômeur) |
+| Chômeurs complets indemnisés en formation professionnelle | C02 |
+| Demandeurs d'emploi inoccupés inscrits obligatoirement, stage d'insertion, DE en formation prof., demandeurs d'allocations, DE sans revenu (conjoint cohabitant avec charge) | C02 *(à confirmer)* |
+| DE dans programmes d'aide à l'emploi (hors ACS/APE) | C02 *(à confirmer)* |
+| Personnes en situation de handicap (document probant) | C03 (handicap) |
+| Bénéficiaires RIS ou ERIS | C04 (RIS) |
+| Miliciens | C07 (autre) *(à confirmer)* |
+| **(9731, nouveau)** Étudiants BES AeSI (180 crédits/3 ans) boursiers (décret allocations d'études 18/11/2021) ou titulaires d'une attestation de boursier (coopération au développement) | C07 *(à confirmer — « sera inséré lors de la prochaine actualisation » de la circulaire dossier personnel)* |
+| Personnel directeur/enseignant/auxiliaire — formation continuée reconnue | C05 (personnel enseignant) |
+| Personnel de l'enseignement CF — recyclage lié à la fonction | C05 |
+| Personnes soumises à une obligation imposée par une autorité publique | C06 (autorité publique) |
+| Inscrits en UE **FLE ≤ A2** (CECRL) | C07 *(à confirmer)* |
+| Inscrits en UE d'**alphabétisation** et UE de niveau **secondaire inférieur dont le CEB n'est pas le titre requis** | C07 *(à confirmer)* |
+
+> ⚠️ **Mapping C01-C07 partiellement hypothétique** (la circulaire liste ~13 conditions, l'enum SEPS
+> en code 7). À confirmer avec l'ETNIC ou la circulaire « dossier personnel » (9593, spec 14) qui
+> détaille les pièces justificatives par motif.
+
+Autres règles d'exonération :
+
+- **Valorisation des acquis / dispense complète** : pas de DI exigible pour les UE dispensées — lien avec
+  `valorisationAcquis` (Organisation v7) et `ValorisationAcquisType` (SEPS). Référence : circ. 6677 du
+  30/05/2018, **remplacée par la circ. 9447 du 25/02/2025** (« Modalités de valorisation des acquis pour
+  l'admission, la dispense partielle ou complète ») — citée par la 9731.
+- **Codiplômation** (≥ 1 étab. supérieur plein exercice CF + 1 étab. EPS, depuis 2024-2025, décret
+  09/11/2023) : DI payé auprès de l'**établissement référent** ; si le référent est le plein exercice,
+  **aucun DI** côté EPS.
+- Les exonérations sont vérifiées **par chaque établissement** à la date du 1ᵉʳ dixième de ses UE
+  (multi-établissements hors codiplômation) ; preuve de paiement de l'autre établissement à archiver
+  dans le dossier étudiant (circ. 9022 → 9593).
+
+## 4. Règles de déclaration (jonction EPROM)
+
+1. **Forfait ↔ Document 1** : le forfait est déclaré dans l'UE dont le **1ᵉʳ dixième est le plus proche
+   du début de l'année académique** ; en cas d'égalité, l'UE **qui se termine en premier**. Le forfait
+   doit être **cohérent avec le comptage du Document 1 (colonnes A et B)** — c'est-à-dire les colonnes
+   UI « **Elèves A** » (col 2, réguliers ≥ 18 ans) et « **Elèves B** » (col 5, réguliers < 18 ans non
+   soumis à l'obligation scolaire à temps plein) du Doc 1 (résolu session 9, spec 20 §1.4).
+2. **Étudiants redevables non en ordre de paiement** : exclus du calcul de l'**encadrement**, de
+   l'**ajustement de la dotation de périodes** et des **dotations/subventions de fonctionnement**
+   → impacte `nbEleves5ieme` (Doc 1D) et les comptages du Doc 1.
+3. **Règle de l'arrondi** (loi 02/05/2019, depuis 01/12/2019) : paiements espèces/électroniques arrondis
+   aux 0/5 cents **sur le total perçu uniquement** — jamais sur le DI calculé par UE. Les discordances
+   minimes DI perçus vs constatés sont tolérées. → `mtDroitsInscription` (Doc 1D) porte des montants
+   **constatés** (non arrondis).
+4. **Frais de dossier (DIC)** : mentionnés par les établissements (synthèse GHA) au prorata des périodes —
+   propres à l'établissement, **hors circulaire DI** et hors `mtDroitsInscription`. Le « périmètre DIC »
+   était déjà un point à confirmer de la session 7.
+
+## 5. Impacts sur les specs existantes
+
+| Spec | Impact |
+|---|---|
+| **06 (Doc 1D)** | ⭐ **Règle explicite 9731 (§2, Remarque)** : « le montant des droits d'inscription pris en compte sur le **Document 1D** doit correspondre au montant total des droits d'inscription **constatés** sur la dernière version du reçu/fiche d'inscription, **qu'il ait été perçu ou non perçu** ». Tout DI perçu doit être constaté et comptabilisé par le vérificateur (l'inverse n'est pas vrai). → `mtDroitsInscription` = constaté, jamais arrondi par UE ; exclusion des non-payeurs du comptage `nbEleves5ieme` |
+| **11 (SEPS Enregistrer Inscription)** | sémantique de `droitInscription`/`MotifExemptionType` (§3) ; pivot du 1ᵉʳ dixième = `regulier1` ; DIS (hors CEE) régi par d'autres textes |
+| **03 (Doc 1 Population)** | cohérence forfait ↔ colonnes A/B ; non-payeurs hors comptages |
+| **04 (Doc 2 Périodes)** | l'assiette DI n'est **pas** le Doc 2 (réellement organisé) mais le dossier pédagogique (Doc 8/8bis) |
+| **05 (Doc 3)** | confirme le rôle de référence de `nbPeriodesDoc8` (périodes « dossier pédagogique ») |
+
+## 6. Points ouverts
+
+- ~~Extraire du PDF 9731 les montants 2026-2027~~ ✅ fait (34 € / 0,30 / 0,47). Reste : tarif supérieur
+  2025-2026 exact de la 9488 (anecdotique — année écoulée).
+- Confirmer le mapping exonérations ↔ `MotifExemptionType` C01-C07 (ETNIC / 9593 ; la 9731 renvoie
+  explicitement à la circulaire « dossier personnel » pour le détail des cas). Le cas BES AeSI boursier
+  (nouveau 2026-2027) n'a probablement **pas encore de code SEPS dédié**.
+- La 9217/9731 référencent la **8684** pour le comptage Document 1 (colonnes A/B) → voir spec 17.
+- Se procurer la **9447** (VA admission/dispense, 25/02/2025) si la VA devient un sujet pyetnic.

--- a/specs/17_circulaire_9487_calendrier_dotation.md
+++ b/specs/17_circulaire_9487_calendrier_dotation.md
@@ -1,0 +1,123 @@
+# Circulaire 9487 (16/04/2025) — Calendrier général EA 2025-2026 et gestion de la dotation de périodes
+
+> Spécification fonctionnelle « temporalité des UE » pour les services EPROM.
+> Source : `circulaires/52387_0000.pdf` (16 p., texte natif). Circulaire d'instruction, validité 25/08/2025.
+> Abroge et remplace la 9244 du 25/04/2024 (circulaire annuelle ; structure stable d'année en année).
+> Gestionnaire : Direction EPS — **Service de la Vérification** (mêmes contacts que circulaires DI et 8684).
+> Date d'analyse : 2026-06-10 (session 8)
+
+---
+
+## 1. Cadre temporel de l'année académique 2025-2026
+
+| Élément | Valeur |
+|---|---|
+| Rentrée académique | **lundi 25/08/2025** |
+| Fin de l'année académique | **dimanche 23/08/2026** |
+| Vacances d'été | à partir du samedi 04/07/2026 |
+| Base légale flexibilité horaire | art. 14 du **décret du 16/04/1991** |
+
+> **Les UE peuvent être planifiées à tout moment de l'année, en journée ou en soirée, selon un rythme
+> hebdomadaire variable et une intensité modulable.** Il n'y a pas de « grille horaire » imposée — seule
+> la fenêtre de l'année académique borne l'organisation.
+
+### Jonction spec 02 (Formation Organisation v7)
+
+- Erreurs `20010` (« date début ne peut être inférieure à xx/xx/xxxx ») et `20011` (« date fin ne peut
+  être supérieure à xx/xx/xxxx ») : les bornes paramétrées côté serveur correspondent
+  vraisemblablement aux **dates de l'année académique** de l'`anneeScolaire` visée (ici 25/08/2025 →
+  23/08/2026). À vérifier en TQ.
+- Erreur `20012` (fin ≤ début + 1 an) : cohérent avec une année académique de 52 semaines.
+- `numOrganisation2AnneesScolaires` : une UE peut chevaucher deux années académiques ; son
+  rattachement administratif suit la règle du **1ᵉʳ dixième** (cf. spec 16 §2).
+- `nombreSemaineFormation` (calculé, 1-52, erreur `20013`) : découle des dates début/fin.
+
+### Régime des congés (2025-2026)
+
+| Type | Code calendrier | Régime |
+|---|---|---|
+| Jours fériés légaux | `CO` | cours **interdits** (13 jours listés, du 27/09/2025 au 15/08/2026) |
+| Vacances d'hiver (22/12/2025 → 02/01/2026) | `VH` | suspension **obligatoire** (AE 22/03/1984, art. 3) ; étendue au samedi 03/01 si cours le samedi |
+| Vacances d'automne / détente / printemps | `VA`/`VD`/`VP` | suspension **facultative** |
+| Vacances d'été | `VE` | dès le 04/07/2026 |
+| Jours de suspension facultatifs | `JS` | au choix de l'établissement, à identifier au calendrier |
+
+L'établissement renvoie son **calendrier général de fonctionnement** (modèle Excel en annexe) au
+Service de la Vérification (`verification.eps@cfwb.be` + vérificateur de l'établissement) **avant le
+30/09/2025**. Le calendrier couvre **toutes** les activités d'enseignement, y compris l'encadrement
+des stages et les épreuves intégrées.
+
+## 2. ⭐ Règle des 100 % planifiés / 90 % dispensés
+
+1. **Planification** : l'horaire d'une UE doit couvrir **100 % des périodes prévues au dossier
+   pédagogique** (périodes d'autonomie comprises). Base légale : décret 16/04/1991, art. 136
+   (approbation provisoire des UE) et 137 (approbation définitive des dossiers de référence).
+   Concrètement : « il est impératif d'intégrer l'ensemble des périodes prévues dans le
+   **document 8bis** de chaque UE à l'horaire ».
+2. **Réalisation** : si des jours de cours sont annulés (congés, suspensions, absences non remplacées),
+   **au minimum 90 % des périodes doivent être assurées** — sinon la fin de l'UE est **reportée**
+   (prolongation au-delà de la semaine de fin prévue, ou cours supplémentaires).
+3. **Comptabilisation des suspensions** :
+   - périodes tombant un `CO` ou en `VH` → **réputées dispensées** si le seuil de 90 % reste atteint,
+     sinon reprogrammation obligatoire ;
+   - périodes tombant en `VA`/`VD`/`VP`/`VE` non effectivement prestées → **jamais** réputées
+     dispensées, reprogrammation **systématique**.
+4. **Enjeu FSE** : financement sollicité sur 100 % des périodes → toute UE planifiée à <100 % rend la
+   différence inéligible (cas d'audit cité). Responsabilité du chef d'établissement / PO.
+5. Remplacement des enseignants absents (maladie/infirmité) possible **dès le 1ᵉʳ jour ouvrable** si
+   l'absence dure ≥ 6 jours ouvrables consécutifs (spécificité EA — continuité pédagogique).
+
+### Jonction specs 04 (Doc 2) et 05 (Doc 3)
+
+| Donnée service | Interprétation à la lumière de la 9487 |
+|---|---|
+| `nbPeriodesDoc8` (Doc 3) | périodes du **dossier pédagogique / document 8bis** = la référence 100 % |
+| `nbPeriodesPrevuesDoc2` | périodes **planifiées** à l'horaire (obligation : = 100 % du Doc 8bis) |
+| `nbPeriodesReellesDoc2` | périodes **effectivement dispensées** (obligation : ≥ 90 % du Doc 8bis, en comptant les CO/VH réputées dispensées) |
+
+> Exemple normatif de la circulaire : UE de 120 périodes (12/semaine : 6 lu + 6 je), semaines 25→35 ;
+> jours fériés + VP suspendus → 102 périodes dispensées < 108 (90 % de 120) → compensation ou
+> prolongation obligatoire. → Un contrôle client `reelles ≥ 0,9 × doc8bis` est un garde-fou pertinent
+> (la valeur exacte des « réputées dispensées » CO/VH reste côté établissement).
+
+## 3. Gestion de la dotation de périodes
+
+- L'année académique est découpée, **pour la gestion de la dotation**, en **16 semaines sur 2025 et
+  24 semaines sur 2026** (40 semaines numérotées, indépendantes de la numérotation ISO du
+  calendrier — voir annexe : semaines 1 à 40, de fin août à début juillet).
+  **« Cette répartition sera maintenue pour les années suivantes. »**
+- La **dotation de périodes de l'année civile 2026** est communiquée aux établissements **avant le
+  31/07/2025**. (La dotation est donc gérée par **année civile**, à cheval sur deux années académiques —
+  d'où le découpage 16/24.)
+- Lien DI (spec 16) : les étudiants redevables non en ordre de paiement sont exclus de l'**ajustement
+  de la dotation de périodes**.
+- Le calcul de la dotation elle-même (formule, ajustement) n'est **pas** dans cette circulaire → voir
+  8684 « Renseignements annuels » (spec 19) et les circulaires « dotation » spécifiques.
+
+### Numérotation des semaines (annexe 2025-2026)
+
+Semaine 1 = semaine du 25/08/2025 ; numérotation continue jusqu'à la semaine 40 (≈ 29/06/2026),
+en sautant les semaines entièrement en vacances (VA, VH, VD, VP non numérotées dans l'annexe).
+→ 16 semaines numérotées en 2025 (1-16), 24 en 2026 (17-40).
+
+> ⚠️ Cette numérotation « dotation » est un **référentiel métier propre à l'EA** (≠ semaines ISO 8601).
+> Si pyetnic expose un helper calendrier, prévoir la conversion date ↔ semaine de dotation à partir du
+> calendrier annuel publié (l'exemple §2 — « débute en semaine 25, se termine en semaine 35 » —
+> utilise cette numérotation).
+
+## 4. Impacts sur les specs existantes
+
+| Spec | Impact |
+|---|---|
+| **02 (Organisation v7)** | bornes probables des erreurs `20010`/`20011` = année académique ; sens de `nombreSemaineFormation` ; UE à cheval (`numOrganisation2AnneesScolaires`) |
+| **04 (Doc 2 Périodes)** | sémantique prévu (=100 % Doc 8bis) vs réel (≥90 %) ; règles CO/VH vs VA/VD/VP |
+| **05 (Doc 3)** | `nbPeriodesDoc8` = référence réglementaire de l'horaire |
+| **16 (DI)** | rattachement des UE à l'année académique (fenêtre 25/08 → 23/08) pour la règle du 1ᵉʳ dixième |
+
+## 5. Points ouverts
+
+- Vérifier en TQ que les bornes serveur `20010`/`20011` = dates de l'année académique de la circulaire.
+- Récupérer la circulaire calendrier **2026-2027** (successeur de la 9487, parution ~avril 2026) pour
+  les dates à jour — le mécanisme est stable.
+- Identifier la circulaire « dotation de périodes » proprement dite (communication annuelle avant le
+  31/07) — probablement un courrier individuel par établissement plutôt qu'une circulaire publique.

--- a/specs/18_circulaire_8829_hybride.md
+++ b/specs/18_circulaire_8829_hybride.md
@@ -1,0 +1,108 @@
+# Circulaire 8829 (01/02/2023) — Enseignement hybride : conditions d'organisation et encodage EPROM
+
+> Source : `circulaires/50609_000.pdf` (15 p. dont annexe AGCF, texte natif). Circulaire administrative,
+> validité 01/02/2023, **toujours en vigueur** (jamais abrogée). Base légale : **AGCF du 21/12/2022**
+> (effets dès la rentrée 2022-2023), en annexe 1 de la circulaire.
+> Date d'analyse : 2026-06-10 (session 8)
+
+---
+
+## 1. ⭐ « DOC A » identifié — résolution du point ouvert sessions 4/5
+
+La circulaire écrit (section « Encodage du Document A ») :
+
+> « Lors de l'encodage du **DOC A (déclaration d'ouverture dans l'application Eprom)**, il convient
+> de cocher la case « enseignement hybride » si l'UE / AF est organisée sous cette forme. »
+
+et : « il ne sera plus possible d'utiliser les cases « **e-learning** » et « **partiellement à
+distance** » […] La case « **enseignement hybride** » devra donc être cochée ».
+
+Ces trois « cases » sont exactement les champs `eLearning`, `partiellementDistance`,
+`enseignementHybride` de **`FormationOrganisationCT`** (service Formation Organisation v7, spec 02).
+
+**Conclusion** : **Doc A = la déclaration d'ouverture = le document « Organisation »** (géré par le
+service Formation Organisation), et **non le Document 1 (Population)** comme supposé en session 4.
+
+Conséquence sur le workflow inter-documents (erreur `20102` du Doc 3 : « Les "Doc A" et "Doc 2"
+doivent être approuvés pour pouvoir accéder au "Doc 3" ») :
+
+```
+Organisation (« Doc A », statut StatutCT → Approuvé) ─┐
+                                                       ├─► Document 3 (Attributions) accessible
+Document 2 (Périodes, swAppD2=1) ─────────────────────┘
+
+Document 1 (Population) et Doc 1D (Droits) : workflows propres, non bloquants pour le Doc 3
+(sous réserve du libellé exact : voir « Limite » ci-dessous).
+```
+
+> **Limite** : le manuel du Doc 3 reste ambigu (libellé littéral « Doc A »), mais la 8829 fournit la
+> première **définition officielle** du terme. L'ancienne hypothèse « Doc A = Document 1 » est
+> rétrogradée ; on note toutefois que la vue Formations Liste fusionne Population+Périodes dans un
+> même statut, donc un test TQ (approuver Organisation+Doc 2 sans approuver Doc 1, puis appeler
+> Doc 3) trancherait définitivement.
+
+## 2. Définition et conditions d'organisation de l'hybride
+
+- **Enseignement hybride** = forme d'enseignement **mixant** des activités d'apprentissage en
+  présentiel et à distance (synchrone ou asynchrone), avec outils numériques de communication /
+  interaction / collaboration. Remplace l'« e-learning » depuis le 29/08/2022.
+- **Organisation distincte** : toute UE/AF en hybridation fait l'objet d'une **organisation distincte**
+  de celle proposée entièrement en présentiel (art. 3 AGCF) → côté EPROM, **deux
+  `numOrganisation` différents** pour la même UE selon le mode.
+- **Concertation sociale préalable** obligatoire (art. 2 AGCF) — sauf bascule exceptionnelle.
+- **Bascule exceptionnelle présentiel → hybride** (art. 3) : possible pour raisons conjoncturelles
+  (grève des transports, confinement…) avec **préavis de 48 h** ; dans ce cas **ni avis de
+  concertation ni déclaration à l'Administration** → l'organisation EPROM reste « présentiel ».
+- **Horaire obligatoire pour toutes les activités**, quel que soit le mode (présentiel, distanciel
+  synchrone ou asynchrone), et respect du **volume total des périodes du dossier pédagogique**
+  (cohérent avec la règle 100 %/90 % — spec 17).
+- Une même organisation hybride peut comporter **plusieurs groupes d'étudiants** ; la scénarisation
+  pédagogique (art. 5 AGCF) s'applique intégralement par mode et par groupe, sinon étudiants
+  considérés absents.
+- **AF (activités de formation)** : mêmes règles (réf. circulaire 6351 du 13/09/2017) — lien avec le
+  switch `activiteFormation` (Organisation v7).
+
+## 3. Neutralité sur les périodes, la dotation et le DI
+
+L'hybride est **strictement neutre** sur les paramètres de financement :
+
+1. **Cadre PNCC** (personnel non chargé de cours) : périodes-élèves = total des périodes des UE/AF
+   suivies par tous les élèves **réguliers** (hors cas particuliers) — comme en présentiel.
+2. **Ajustement de la dotation de périodes** : périodes-élèves **pondérées** calculées comme en
+   présentiel.
+3. Les périodes prévues au dossier pédagogique de l'UE hybride sont **prélevées de la dotation de
+   périodes** de l'établissement — comme en présentiel.
+4. **DI inchangé** : mêmes montants, mêmes exemptions, mêmes conditions de régularité (spec 16).
+
+> → Pour pyetnic : `enseignementHybride` est un **marqueur déclaratif** (statistique + état des lieux
+> pluriannuel gouvernemental) sans effet sur les calculs de périodes/DI. La circulaire insiste sur le
+> respect « scrupuleux » de cette instruction d'encodage.
+
+## 4. Traçabilité documentaire (hors services SOAP, utile au contexte)
+
+- Reçu/fiche d'inscription : UE hybrides identifiées par la lettre **M**.
+- Listes de présence : mention **HYBRIDE** ; codes de présence : `P` (ou trait vertical) présence en
+  classe, **`M` cours à distance**, `A` (ou trait horizontal) absent, `D` dispensé partiellement.
+  Les anciens codes `HA`/`HS` (circulaire 8710 du 05/09/2022) sont abrogés, lus comme `M`.
+- Cours asynchrone : participation rattachée à la **date prévue à l'horaire initial** ; comptage selon
+  la participation validée par le chargé de cours ; justificatifs à disposition du vérificateur.
+- Dossier étudiant identique au présentiel (pièce d'identité, reçu signé, paiement DI ou exemption
+  valable à la date du **1ᵉʳ dixième**…).
+
+## 5. Impacts sur les specs existantes
+
+| Spec | Impact |
+|---|---|
+| **02 (Organisation v7)** | sémantique précise de `enseignementHybride` (≥ 2022-2023, erreurs `20031`/`30008`) ; `eLearning`/`partiellementDistance` interdits pour UE débutant ≥ 29/08/2022 ; organisation hybride = organisation **distincte** ; bascule 48 h sans réencodage |
+| **05 (Doc 3)** | ⭐ « Doc A » (erreur `20102`) = **Organisation**, pas Document 1 — hypothèse session 4 corrigée |
+| **04 (Doc 2)** | volume des périodes du dossier pédagogique inchangé en hybride ; périodes-élèves (pondérées) calculées comme en présentiel |
+| **16 (DI)** | hybride sans effet sur le DI |
+
+## 6. Points ouverts
+
+- Test TQ pour confirmer définitivement le déclencheur de `20102` (approbations Organisation + Doc 2
+  suffisantes ?).
+- Récupérer la circulaire **6351** (13/09/2017, activités de formation) si le switch `activiteFormation`
+  doit être documenté plus finement.
+- Annexe 1 (texte AGCF 21/12/2022) non dépouillée en détail (attributions chargé de cours / PO —
+  hors périmètre pyetnic).

--- a/specs/19_circulaire_8684_renseignements_annuels.md
+++ b/specs/19_circulaire_8684_renseignements_annuels.md
@@ -1,0 +1,234 @@
+# Circulaire 8684 (16/08/2022) — Renseignements annuels : instructions d'encodage EPROM
+
+> **LA circulaire métier des services EPROM** : instructions officielles d'encodage des Documents A, 1,
+> 1D, 2 et 3 dans « EPROM Formations ». Source : `circulaires/49854_000.pdf` (90 p. : 25 p. de corps +
+> 8 annexes dont manuels HOD/CICS et EPROM). **Toujours en vigueur** (jamais abrogée ; abroge la 6313,
+> complète la 6382). Gestionnaire : Direction EPS — Service de la Vérification.
+> Validité : année 2022-2023 (les exemples d'années civiles 2022/2023 se transposent).
+> Date d'analyse : 2026-06-10 (session 8)
+
+---
+
+## 0. Confirmations structurantes
+
+1. ⭐ **« DOCUMENT A » = « Déclaration d'organisation »** (titre de la section 2.1) — double
+   confirmation de la découverte de la spec 18 : Doc A = le document Organisation (service Formation
+   Organisation v7).
+2. ⭐ **Les web services EPROM sont officiellement prévus** (§ Doc 1D, encadré) : « L'Administration a
+   mis à la disposition des développeurs d'applications de gestion (ENORA, GIPS, PROSOC…) la
+   possibilité d'organiser les transferts d'informations relatives aux **DOCUMENTS A, 2, 1D et 3** par
+   l'utilisation de **webservices** […] en un seul encodage. » → c'est exactement le périmètre pyetnic
+   (Organisation, Doc 1+2, Doc 1D, Doc 3).
+3. **Workflow** : le Document 2 « est **généré par l'application** pour toute formation déclarée
+   ouverte par un DOCUMENT A **et approuvée par l'Administration** » → le Doc 2 n'existe qu'en aval
+   d'un Doc A approuvé (cohérent avec `20102` et la génération des lignes du Doc 3 depuis le Doc 2).
+4. **Accès à l'application** : `www.am.cfwb.be`, comptes `ec00xxxx@adm.cfwb.be` / `po00xxxx@…`
+   (xxxx = matricule FASE) ; PO = consultation d'office, « approbation » sur demande au Service de la
+   Vérification → éclaire les statuts « Encodé école » / « Encodé PO » / « Approuvé » (`StatutCT`).
+
+## 1. DOCUMENT A — déclaration d'organisation (→ spec 02)
+
+- **Seule preuve d'ouverture** d'une formation ; initie tout le processus déclaratif.
+- **Numéro de séquence attribué par le système** (nombre d'organisations non limité) = `numOrganisation`.
+- Données : dates **réelles** de début/fin, nombre de semaines, intervention extérieure éventuelle,
+  et finalités à cocher — correspondance directe avec `FormationOrganisationCT` :
+
+| Finalité (circulaire) | Champ service |
+|---|---|
+| uniquement périodes supplémentaires et/ou EPT | `organisationPeriodesSupplOuEPT` |
+| uniquement organisation de la valorisation | `valorisationAcquis` |
+| partiellement à distance (→ hybride dès 2022-2023, spec 18) | `enseignementHybride` |
+| milieu carcéral | `enPrison` |
+| activités de formation (circ. 6351) | `activiteFormation` |
+| intervention extérieure | `typeInterventionExterieure` (+ détail au Doc 2) |
+
+  ⚠️ La case « uniquement périodes suppl./EPT » ne doit **pas** être cochée pour le suivi
+  pédagogique (ligne 96 — voir §3.4).
+
+- **UE sur 2 années scolaires** : **deux** Documents A — le 1ᵉʳ dans l'année du **1ᵉʳ dixième**, le 2ᵈ
+  l'année suivante avec **le numéro d'organisation de l'année précédente**
+  (= `numOrganisation2AnneesScolaires`). Les deux mentionnent les dates réelles de **l'ensemble** de
+  la formation. Art. 14 du décret 16/04/1991 : début et fin séparés de **365 jours calendrier max**
+  (= erreur `20012`).
+- **Après validation** : la formation est « ouverte » ; toute modification/suppression passe par le
+  **Service de la Vérification** (courriel) — éclaire la contrainte `30003` et le caractère sensible de
+  `ModifierOrganisation`/`SupprimerOrganisation`.
+- **Désactivation automatique** : un dossier pédagogique non activé dans les **4 ans** de
+  l'autorisation est désactivé ; réactivation préalable obligatoire (annexe 1 ; circ. 5273/5447) —
+  cause plausible de l'erreur `20029` (« date début ≥ date fermeture formation »).
+- **Échéance** : transmission dans les **5 jours ouvrables suivant la fin de la semaine du 1ᵉʳ jour de
+  cours**.
+
+## 2. DOCUMENT 1 — populations au 1ᵉʳ dixième (→ spec 03)
+
+Onglet « POPULATIONS », tableau « par année d'étude » (16 colonnes, 9 à renseigner). Le 1ᵉʳ et le 5ᵉ
+dixième sont **calculés d'après les dates du Doc A**. Sémantique officielle des colonnes :
+
+| Col. | Contenu | Remarques |
+|---|---|---|
+| 1 | année d'étude | préremplie |
+| 2 | étudiants réguliers **≥ 18 ans** au 1ᵉʳ dixième (exonérés ou non du DI) | exclut ceux des col. 3 et 5 ; un étudiant déjà en col. 2 d'une autre formation ne va que dans la col. 8 |
+| 3 | réguliers inscrits pour la 1ʳᵉ fois via un **CEFA** | |
+| 4, 4' | ~~FSE HPI / FSE PI~~ | **plus demandées** (≈ `nbEleveFse`/`nbElevePi` obsolètes de la spec 03) |
+| 5 | réguliers **< 18 ans** non soumis à l'obligation scolaire à temps plein | |
+| 6 | **auto** = 2+3+5, étudiants « **comptés 1 fois** » (jamais déjà dans une col. 6 d'un autre Doc 2 de l'année) | |
+| 7 | exemptés DI sur attestation **FOREM/ACTIRIS/VDAB/Arbeitsamt** | sous-ensemble de la col. 2 |
+| 7' | exemptés DI **RIS/ERIS** (CPAS, ILA, Fedasil) | sous-ensemble de la col. 2 |
+| 7'' | exemptés DI **autres motifs** | sous-ensemble de la col. 2 |
+| 8 | réguliers multi-formations déjà comptés dans une col. 6 ailleurs (« **comptés plusieurs fois** ») | |
+| 9 | **auto** = 6+8 = total des inscriptions | |
+| 10, 10' | ~~FSE comptés plusieurs fois~~ | plus demandées |
+| 11, 11' | total réguliers **masculin** / **féminin** | |
+
+- **Validation** : case à cocher + sauvegarde → données **figées** (= `swAppPopD1` posé via
+  `ApprouverDocument1`). Cette validation **ouvre la partie périodes (Document 2)**.
+- « Le Document 1 doit être transmis **en même temps** que le Document 2 » (35 jours, cf. §6).
+- Jonctions session 7 confirmées : col. 7/7'/7'' ↔ exemptions DI (`MotifExemptionType` SEPS) ;
+  comptage 1 fois / plusieurs fois ↔ logique `regulier1`/`regulier5`.
+
+## 3. DOCUMENT 2 — périodes organisées (→ spec 04)
+
+### 3.1. Tableau « population par activité d'enseignement » (colonnes 12-19)
+
+| Col. | Contenu | Champ service probable |
+|---|---|---|
+| 12 | branche préremplie + n° d'ordre administratif | `coNumBranche` + `teNomBranche` (+ `coCategorie`) |
+| 13 | année d'études | `noAnneeEtude` |
+| 14 | nb d'étudiants réguliers au 1ᵉʳ dixième suivant la branche (hors dispensés) | population par branche |
+| 15 | **auto** : total des périodes organiques de la branche (**document 8bis**) | `nbPeriodesDoc8` (Doc 3) |
+| 16/17 | périodes **organiques effectives** de la 1ʳᵉ/2ᵉ **année civile** | prévues an 1 / an 2 |
+| 18/19 | périodes **réellement organisées** (dédoublements compris) 1ʳᵉ/2ᵉ année civile | réelles an 1 / an 2 |
+
+**Règles de cohérence officielles** (sources probables des erreurs `4004`-`4012`, `1527`/`1528`,
+`1574`) :
+
+1. UE entièrement organisée dans l'année : **col 16 + 17 = col 15**. UE sur 2 années
+   scolaires : 16+17 < 15 par Doc 2, mais la **somme des deux Documents 2 = Doc 8bis**.
+2. **Col 18 = multiple entier de col 16** (idem 19/17), sauf suppression de dédoublement ou
+   regroupement — **permis uniquement au 5ᵉ dixième**.
+3. Ligne par ligne : **18+19 = multiple entier ou entier-et-demi de 15** (explique les périodes en
+   `float` — « multiple entier et demi »).
+4. **Encadrement** (stage, épreuve intégrée) : 18+19 = **col 14 × périodes prévues par étudiant**
+   (Doc 8) — strictement.
+5. UE à cheval sur les 2 semestres : périodes **obligatoires sur les deux années civiles**
+   (« conforme à la réalité de terrain »).
+6. **Somme des totaux 18+19 = total des périodes attribuées aux professeurs titulaires** au Doc 3
+   (hors remplacements) — c'est l'erreur `1574` côté Doc 3.
+7. Les périodes des col. 18/19 sont **décomptées de la dotation de périodes organique de l'année
+   civile correspondante** → c'est la raison d'être de la ventilation par année civile (la dotation
+   est gérée par année civile, 16+24 semaines — spec 17).
+
+### 3.2. Lignes spéciales (référentiel `coNumBranche`/catégories)
+
+| Ligne | Usage | Règles |
+|---|---|---|
+| 91/93 | **valorisation** : admission ou dispense (formelle/informelle/non formelle) | circ. 6677 → 9447 |
+| 92/94 | **valorisation** : sanction | encodage possible **après approbation**, jusqu'au **31/10 de l'année scolaire suivante** |
+| 95 | **expertise pédagogique et technique** (périodes supplémentaires) | min. **40 périodes par chargé de cours** sur dotation organique (pas de minimum en IE) |
+| 96 | **suivi pédagogique** (art. 5bis 25°/27° et 91/6 du décret) | sur dotation organique **ou** pot K ; **aucun DI** ; **aucune population** aux 1ᵉʳ/5ᵉ dixièmes → « valider les Document 1 et Document 1D **sans population** » ; UE « à blanc » possible (conseiller à la formation, méthodes de travail, orientation/guidance, remédiation math/français) |
+
+> Art. 91/6 : plafond global de **10 % de la dotation organique** pour conversions d'emplois, conseil
+> des études, admission/suivi/sanction, expertise, activités de formation (sauf dérogation et
+> conventions art. 114).
+
+### 3.3. Regroupements
+
+- Encodés dans un cadre dédié : n° administratif de la formation où la branche est réellement
+  dispensée + n° d'organisation + n° d'activité + année d'étude (= champs `regroupement*` du Doc 2,
+  erreurs `1527`/`1528`).
+- Conditions de l'AGCF du 20/07/1993 (art. 5) : même **niveau**, même **catégorie de cours**, même
+  **nombre de périodes**, mêmes **capacités terminales/acquis d'apprentissage**.
+- Étudiants regroupés comptés **une seule fois**, dans la formation où la branche est enseignée ;
+  dans l'autre formation, col. 16-19 = 0 pour la branche regroupée.
+- ⚠️ Regroupements non conformes : périodes **déduites complètement de la dotation**.
+
+### 3.4. Interventions extérieures (IE)
+
+- **Définition** : toute utilisation de périodes d'origine **autre qu'organique**, ne devant pas
+  intervenir dans le **calcul de l'ajustement de la dotation** : conventions, projets FSE, périodes
+  « cabinet », périodes complémentaires, conversion d'emploi NCC (antigel)…
+- Les périodes IE **n'entrent pas** dans l'ajustement de la dotation **mais comptent** pour les
+  périodes-élèves (encadrement) → ventilation obligatoire cas **généraux** vs cas **particuliers**
+  (art. 21 AECF 27/12/1991).
+- **TYPE + SOUS-TYPE** (annexe 2) = exactement les tables `coCatCol` (type, 1 lettre) et `coObjFse`
+  (sous-type, 2 lettres) de la spec 04 : A (PNCC), B (périodes suppl.-bonus : AE/AL/RE), C (Convention :
+  AC/AF/BF/CA/CD/CE/CF/CO/FC/FO/FP/FS/NE/RW), D (discriminations positives), E (EHR), F (Fonds
+  européens : BW/BX/CG/WL), G (antigel), I (publics infrascolarisés : AP/BF/CC/CI/CP/CQ/CS/FO/MI/NT),
+  K (périodes cabinet : EL/EN/IN/PP/PR/RC/SP), P (formations continuées), Q (Agence Qualité),
+  U (UE : RR), V (validation des compétences). Liste « non exhaustive, susceptible d'évoluer » ;
+  chaque type a **sa propre circulaire administrative**.
+- **Contrôle global** : total IE + colonnes 18/19 = **périodes effectivement utilisées** pour la
+  formation (= plafonds du Doc 3, erreurs `1575`/`1576` CG/CP).
+- Cas particuliers (annexe 3) : Coordinateur Qualité, Conseiller à la formation, Personne de référence
+  EPS inclusif → UE dédiées (codes `980301U21D1`/`980302U21D1`/`980302U36D1`/`980303U21D1`…),
+  branche 1 « ORIENTATION GUIDANCE », volumes en multiples de 20/25/30 périodes selon barème A/B/C,
+  pots A (conversion PNCC), K (suivi pédagogique/inclusif IN), I (CQUA via ligne 95).
+- Formule PE des cas particuliers : **périodes réservées × nombre moyen de PE par période organisée**
+  (arrondi 2ᵉ décimale) — la formule repérée dès la session de recherche initiale.
+
+## 4. DOCUMENT 1D (→ spec 06)
+
+- « Vous devez renseigner le nombre d'étudiants réguliers au **5ᵉ dixième** de la formation ainsi que
+  le **montant total des droits d'inscription perçus**. »
+- ⚠️ Évolution terminologique : la **9731** (2026-2027, spec 16) précise désormais que le montant du
+  Doc 1D = DI **constatés** (perçus ou non) — la 8684 (2022) disait « perçus ». La règle 9731, plus
+  récente, fait foi.
+- Échéance : **25 jours calendrier après le 5ᵉ dixième**.
+
+## 5. DOCUMENT 3 (→ spec 05)
+
+- Particularité : **reste toujours accessible en modification** (contrairement aux Doc A et 2) — pour
+  concordance permanente avec les documents de traitement (**PROM S 12 / PS CF 12**, cf. circulaire
+  9589 spec 07/08).
+- Remplacements : **lignes supplémentaires** par activité (d'où `enseignant [0..*]` et
+  `coNumAttribution`).
+- Ligne subdivisée si : plusieurs professeurs se partagent les périodes ; partenaire extérieur prend
+  en charge la rémunération (**codes dispo 14 ou 15**) ; remplacements.
+- Statuts : définitif, temporaire, expert… (= table `teStatut`) ; motif d'absence du titulaire via
+  menu déroulant (= table `coDispo`).
+- **Seules les périodes réellement prestées** figurent au Doc 3 ; si un remplaçant ne couvre pas tout,
+  le total Doc 3 < total Doc 2 (le contrôle `1574` est bien un **plafond**, pas une égalité).
+- Échéance : **35 jours calendrier après l'approbation du Document 2**.
+
+## 6. Échéancier récapitulatif (chapitre 4 de la circulaire)
+
+| Document | Échéance |
+|---|---|
+| **Doc A** | 5 jours ouvrables après la fin de la semaine du 1ᵉʳ jour de cours |
+| **Doc 1 + Doc 2** | 35 jours calendrier après le **1ᵉʳ dixième** (transmis ensemble) |
+| **Doc 1D** | 25 jours calendrier après le **5ᵉ dixième** |
+| **Doc 3** | 35 jours calendrier après l'**approbation du Doc 2** |
+| Doc 6 (horaires, hors SOAP) | au 1ᵉʳ dixième |
+| Doc 6bis (PNCC, papier), fiche signalétique | dernier jour ouvrable de septembre (et janvier) |
+| Calendrier général | dernier jour ouvrable de septembre (cf. spec 17) |
+| Registre DIS | 15 janvier / 15 juillet + 15 jours |
+
+## 7. Impacts sur les specs existantes
+
+| Spec | Impact |
+|---|---|
+| **02 (Organisation)** | mapping finalités ↔ switches ; 2 Doc A pour UE sur 2 ans (`numOrganisation2AnneesScolaires`) ; 365 jours max (`20012`) ; modification après validation = via Vérification (`30003`) ; échéance 5 jours ouvrables |
+| **03 (Doc 1)** | sémantique officielle des colonnes 1-11' ; colonnes obsolètes 4/4'/10/10' = champs FSE/PI dépréciés ; validation = figeage ; transmis avec le Doc 2 |
+| **04 (Doc 2)** | sens des périodes prévues/réelles **par année civile** (dotation par année civile !) ; règles de multiples (entier, entier-et-demi) ; encadrement = effectif × périodes/étudiant ; lignes 91-96 ; regroupements (AGCF 20/07/1993) ; IE = `coCatCol`/`coObjFse` avec sémantique complète |
+| **05 (Doc 3)** | toujours modifiable ; concordance paie ; dispo 14/15 = prise en charge partenaire ; total ≤ Doc 2 (`1574` plafond) |
+| **06 (Doc 1D)** | 5ᵉ dixième + montant DI (perçus 2022 → **constatés** 9731) ; à valider « sans population » pour les UE ligne 96 |
+| **16 (DI)** | colonnes 7/7'/7'' = la ventilation des exemptions ; « cohérence forfait ↔ colonnes A et B » *(voir point ouvert)* |
+
+## 8. Points ouverts
+
+- ~~« Colonnes A et B » du Document 1~~ : ✅ **résolu en session 9** (exploration UI, spec 20) — dans
+  l'application, les colonnes 2 et 5 du Doc 1 sont libellées « **Elèves A** » et « **Elèves B** »
+  (réguliers ≥ 18 ans / < 18 ans non soumis à l'obligation scolaire). La « cohérence forfait ↔
+  colonnes A et B » des circulaires DI vise ces deux comptages.
+- La 8684 date de 2022 : vérifier l'existence d'un **successeur** (aucune abrogation sur Gallilex au
+  10/06/2026 — elle reste la référence) et surveiller les ajouts de catégories/lignes annoncés « par
+  circulaire, note ou courriel ».
+- Échéances vs erreurs `20030` (« date début ne peut excéder 4 mois ») : le lien exact (délai
+  d'encodage rétroactif ?) reste à confirmer. **Précision mesurée en production le 11/06/2026** :
+  le délai s'applique à l'**anticipation** (date de début future), pas au rétroactif —
+  `CreerOrganisation` avec début au 15/09/2026 (J+3 mois 4 j) accepté, début au 03/11/2026
+  (J+4 mois 22 j) rejeté avec `20030`. La borne exacte (J+4 mois calendaires ?) reste à cerner
+  entre ces deux points. Le rétroactif passe : début au 09/03/2026 (J−3 mois) accepté le
+  11/06/2026 (queue 2 années scolaires de l'UE 510).
+- HOD/CICS (écran 59, pot K) : système hôte historique de consultation de la dotation — hors
+  périmètre SOAP mais utile pour comprendre les références « écran 59 » dans les libellés.

--- a/specs/20_exploration_ui_eprom.md
+++ b/specs/20_exploration_ui_eprom.md
@@ -1,0 +1,217 @@
+# Exploration de l'application EPROM Web (2.12.0) — confrontation UI ↔ specs
+
+> Session 9 (2026-06-10) — exploration **en lecture seule** de l'application de production
+> (`enseignement.cfwb.be/EPROM_WEB`, compte collectif école EICA Auvelais, année 2024-2025,
+> formation témoin : 157 « ESS - Méthodes de travail », code `971111U21D2`, organisation n° 1).
+> Objectif : valider les déductions des specs 01-19 contre la réalité de l'interface.
+
+---
+
+## 1. Confirmations majeures
+
+### 1.1. ⭐ « Doc A » : définitivement confirmé
+
+L'écran d'une organisation (« Description de l'organisation de la formation ») contient un tableau
+**« DOCUMENTS ANNUELS »** :
+
+| Type Document | Date Encodage | Statut | Date de màj du statut |
+|---|---|---|---|
+| **Doc A** | 21/11/2024 | Approuvé | 04/12/2024 |
+| **Doc 1 et 2** | 11/03/2025 | **Approuvé / Approuvé** | 03/04/2025 |
+| **Doc 1D** | 06/06/2025 | Approuvé | 13/06/2025 |
+| **Doc 3** | 02/03/2026 | **Encodé école** | 02/03/2026 |
+
+- **Doc A = l'organisation elle-même** (l'écran de description porte les champs du Doc A) —
+  triple confirmation (circ. 8829, circ. 8684, UI).
+- « Doc 1 et 2 » est **une seule entrée avec deux statuts** (« Approuvé / Approuvé ») → cohérent avec
+  l'unique `statutDocumentPopulationPeriodes` de `OrganisationApercuCT` (spec 01), qui agrège Doc 1
+  et Doc 2.
+- Les valeurs de statut affichées (« Approuvé », « Encodé école ») = les valeurs de `StatutCT.statut`.
+- **Chaque ligne du tableau est cliquable** et ouvre l'écran du document correspondant.
+
+### 1.2. Tuple de statuts dans la liste des formations
+
+La liste de recherche (« LISTE DES FORMATIONS ORGANISABLES », 110 résultats pour 2024-2025) affiche
+par organisation : `N° du JJ/MM/AAAA au JJ/MM/AAAA` + **`(O - O - O - O - E)`** = les statuts des
+**5 documents dans l'ordre (Doc A, Doc 1, Doc 2, Doc 1D, Doc 3)**, abrégés :
+`O` = apprOuvé, `E` = Encodé (école). L'exemple `(O - O - O - O - E)` correspond exactement au
+tableau ci-dessus. Colonnes de la liste : N° Administratif | Libellé Formation | Code Formation |
+**IE** (lettre du type d'intervention, ex. `I`) | Organisation(s) | Statuts Documents.
+Export **XLS** de la liste disponible (`lnk_generationRapport_imgBtnXls`).
+
+### 1.3. Écran Doc A ↔ `FormationOrganisationCT` (spec 02)
+
+Champs affichés : N° Organisation (1) ; Début 18/04/2024 ; Fin 10/10/2024 ; **Nbr semaines 25** ;
+puis les switches avec leurs libellés UI exacts :
+
+| Libellé UI | Champ service |
+|---|---|
+| Uniquement pour l'organisation de périodes suppl. et/ou d'EPT | `organisationPeriodesSupplOuEPT` |
+| Uniquement pour l'organisation VA | `valorisationAcquis` |
+| Enseignement hybride | `enseignementHybride` |
+| en-prison | `enPrison` |
+| Activité de formation | `activiteFormation` |
+| **Uniquement pour l'organisation de la mission de conseiller en prévention ou de DPO** | `conseillerPrevention` |
+| UE sur 2 années scolaires : **N° d'organisation année précédente** | `numOrganisation2AnneesScolaires` |
+| Informations liées à une organisation en partenariat / Type d'intervention extérieure **à 50 % et plus** | `typeInterventionExterieure` / `interventionExterieure50p` |
+
+> La formation témoin a `numOrganisation2AnneesScolaires = 1` : UE de 60 périodes à cheval
+> 2023-2024 → 2024-2025, déclarée par deux Doc A (cf. règle 8684, spec 19 §1).
+
+### 1.4. Écran « Doc 1 et 2 » (`Description du document annuel 2`) — spec 03/04
+
+Trois onglets : **POPULATIONS | Intervention Extérieure | REGROUPEMENT DES ACTIVITÉS D'ENSEIGNEMENT**.
+
+**⭐ « Colonnes A et B » — point ouvert résolu.** En-têtes réels du tableau
+« POPULATION SCOLAIRE PAR ANNÉE D'ÉTUDES, AU 1/10ᵉ » :
+
+| UI (n° de colonne 8684) | Sémantique (8684/9593) | Champ Doc 1 |
+|---|---|---|
+| Année Études (1) | préremplie | `coAnnEtude` |
+| **Elèves A (2)** | réguliers ≥ 18 ans | — |
+| EHR (3) | inscrits via CEFA *(libellé UI « EHR »)* | — |
+| Elèves FSE HPI (4) / FSE PI (4') | plus demandées | `nbEleveFse`/`nbElevePi` (obsolètes) |
+| **Elèves B (5)** | réguliers < 18 ans non soumis à l'obligation scolaire t.p. | — |
+| Total de 2 à 5 (6) | comptés 1 fois (auto) | — |
+| Demandeur Emploi (7) | exemptés DI FOREM/ACTIRIS/VDAB/Arbeitsamt | `nbEleveDem` |
+| **Minimexés (7')** | exemptés RIS/ERIS | — |
+| Autres exemptés (7'') | autres motifs | `nbEleveExm` |
+| Elèves comptés plusieurs fois (8) | déjà dans un col. 6 ailleurs | — |
+| Total de 6 + 8 (9) | total inscriptions (auto) | — |
+| FSE HPI (10) / FSE PI (10') | plus demandées | obsolètes |
+| Nbre Total Homme (11) / Femme (11') | ventilation par sexe | — |
+| *(dernière colonne)* | **« Validé »** | statut de validation de la ligne |
+
+→ Les « **colonnes A et B** » des circulaires DI = **« Elèves A » (col 2) et « Elèves B » (col 5)** :
+le forfait DI doit être cohérent avec ces comptages de réguliers. (À reporter dans le mapping des
+champs `nbEleve*` de la spec 03 — les noms `A`/`B` sont les libellés métier officiels.)
+
+**Tableau « population par activité d'enseignement »** (colonnes 12-19), en-têtes UI :
+`N° | Catégorie | Activité d'enseignement (12) | Année Études (13) | Nb Elèves (14) | Pér. prévues (15) |
+Prévue (16) 2024 | Prévue (17) 2025 | Réel (18) 2024 | Réel (19) 2025` — la ventilation par **année
+civile** est explicite dans les en-têtes (cf. dotation par année civile, specs 17/19).
+Exemple réel : branche 1 `CTms` Méthodes de travail, 19 élèves, **48,00** (Doc 8bis), prévue 2024
+**20,00**, réel 2024 **20,00** ; branche 2 `Auto` Autonomie **12,00** ; total UE 60 périodes sur
+2 années scolaires (16+17 < 15 conforme à la 8684).
+
+**Lignes spéciales affichées (91-99)** — complète la liste 91-96 de la 8684 :
+
+| Ligne | Catégorie | Libellé UI |
+|---|---|---|
+| 91 | SEtu | VAF impliquant une admission ou une dispense |
+| 92 | SEtu | VAF impliquant la sanction |
+| 93 | SEtu | VANFI impliquant une admission ou une dispense |
+| 94 | SEtu | VANFI impliquant la sanction |
+| 95 | ExPT | EXPERTISE PEDAGOGIQUE ET TECHNIQUE |
+| 96 | SEtu | ADMISSION, SUIVI PEDAGOGIQUE ET SANCTION DES ETUDES |
+| **97** | PeSu | PERIODES S… *(périodes supplémentaires)* |
+| **98** | PSup | PART SUPPLEMENTAIRE |
+| **99** | CEtu | CONSEIL DES ETUDES |
+
+> VAF = valorisation formelle ; VANFI = valorisation non formelle/informelle. Les codes de la
+> colonne « Catégorie » (`CTms`, `Auto`, `SEtu`, `ExPT`, `PeSu`, `PSup`, `CEtu`…) = la table
+> **`coCategorie`** (30 codes, specs 04/05).
+
+**Onglet Intervention Extérieure** (vide pour la formation témoin) : champs
+`Intervention n°` (=`coNumIex`), `Type` (=`coCatCol`), `Sous-Type` (=`coObjFse`),
+`Projet global / Référence` (=`coRefPro`), `N° agrément` (=`coCriCee`) ; tableau « Périodes en
+intervention extérieure » : colonnes **2024 | 2025** (années civiles), lignes **Cas généraux /
+Cas particuliers / Suppléments** (= les `teLibPeriode` des `Doc2PeriodeExt*` de la spec 04).
+
+### 1.5. Écran Doc 1D (`Description du document annuel 1D`) — spec 06
+
+Titre du bloc : « **Droits d'inscription et population au 5/10ᵉ de fonctionnement, comptant pour
+les subventions** ». Colonnes : Année Études | Nombre d'élèves | Droits d'inscription |
+**Droits d'inscription occupationnel** (toujours affiché bien que « plus utilisé ») | **Validé**.
+
+### 1.6. Écran Doc 3 (`Document 3 - Liste des attributions`) — spec 05
+
+Trois compteurs en tête (le mécanisme des plafonds `1574`/`1575`/`1576` rendu visible) :
+**Périodes réelles organiques** (20,00) ; **Périodes prises en interventions extérieures** (0,00) ;
+**Périodes déjà attribuées** (20,00).
+
+Liste des activités : `N°Activité | Catégorie | Activité d'enseignement | Année Études |
+Périodes Doc 8 | Pér. prévues doc2 | Pér. réelles doc2` — mapping 1:1 avec `Doc3ActiviteDetailCT`
+(valeurs affichées en décimal « 48,00 » → confirme la nature `float` malgré le XSD `int`, cf.
+divergence spec 05). Détail d'une activité : `N°Attribution | Enseignant | Code dispo | Statut |
+Périodes attribuées | Suppr.` = `Doc3EnseignantDetailCT`.
+
+## 2. ⭐ Référentiels extraits de l'UI (listes déroulantes du Doc 3)
+
+### 2.1. `teStatut` (8 options dont vide) — libellés officiels
+
+| Code (spec 05) | Libellé UI |
+|---|---|
+| C | ACS |
+| P | ACS Discriminations **P**ositives |
+| A | Définitif **A**ccessoire |
+| D | **D**éfinitif |
+| E | **E**xpert |
+| X | E**X**pertise pédagogique et technique |
+| T | **T**emporaire |
+
+*(Correspondance lettre↔libellé déduite des initiales — ordre UI : ACS, ACS DP, Déf. Accessoire,
+Définitif, Expert, eXpertise, Temporaire ; à figer après un Lire SOAP de contrôle.)*
+
+### 2.2. `coDispo` (60 codes + vide) — libellés officiels
+
+`BE` Bénévolat · `02` Dispo retrait emploi intérêt service · `03` Dispo mesure disciplinaire ·
+`04`/`11` Dispo mission spéciale gvt/orga inter. · `05` Dispo maladie (même traitement) ·
+`07` Dispo convenances personnelles · `09` Absence longue durée raisons familiales ·
+`12` Congé mission cabinet du Roi · `13` Congé mission groupe politique ·
+**`14` Accompagnement FSE ou EHR** · **`15` Périodes prises en charge Convention** ·
+`20` Congé interr. carrière (rempl. chômeur) · `23` Accident de travail ·
+`24` Maladie professionnelle · `25` Dispo maladie (autre traitement) ·
+`27` Congé maladie/infirmité rémunéré · `28` Congé maternité rémunéré CF ·
+`29` Congé allaitement ou parental · `30` Congé interr. carrière (pas rempl.) ·
+`31` Congé de prophylaxie · `33` Désignation juré / désignation provisoire (2 entrées) ·
+`35` Congé mission SHAPE · `36` Dispo mission école européenne · `37` Congé mission orga. jeunesse ·
+`38` Congé mission cabinets/jurys CF · `39` Congé mission associations parents ·
+`44` Congé mission… · `46` Congé pour suivre des cours · `47` Prest. réduites 50+ & 2 enf. <14 ·
+`48` Détachement fct sél/promo (titulaire malade) · `50` Congé mission enseign./guidance PMS ·
+`52`/`53` Désign. prov. même/autre niveau (titul. malade) · `54` Suspension disciplinaire ·
+`55` Suspension préventive · `58` Congé politique · `60` Congé accueil adoption/tutelle ·
+`61` Congé mission cabinet non CF · `62` Congé mission programme spécifique ·
+`63` Congé mission éduc. permanente · `64` Prest. réduites maladie/infirmité ·
+`65`/`67` Congé mission non repris nb global · `69` Congé syndical permanent ·
+`70` Prest. réduites raisons soc./famil. · `71` Prest. réduites raisons personnelles ·
+`74` Prest. réduites membres du personnel · `76` Congé maladie payé mutuelle ·
+`78` Congé maternité payé mutuelle · `79` Congé raisons familiales · **`80` Détachement EHR/CEFA** ·
+`81` Détachement fct sél/promo (titul. non malade) · `94`/`95` Désign. prov. même/autre niveau
+(titul. non malade) · `97` Absence non réglementairement justifiée ·
+`98`/`99` Dispo mission spéciale (pas nb global).
+
+> Les codes **14/15** (« partenaire extérieur prend en charge la rémunération » — 8684, spec 19 §5)
+> sont bien dans la liste. Recouvrement confirmé avec les « codes DI » de la circulaire 9589 (spec 08).
+
+## 3. Notes techniques d'automatisation (pour de futures explorations)
+
+- **Stack** : IBM WebSphere JSF (« hxclient » v3.1.12), JSP : `rlRlFormationsOrganisations.jsp`
+  (recherche+liste+description, multi-écrans sur la même URL), `dlDlOrganisation.jsp`,
+  `dDDocument1D.jsp`, `dDDocument3.jsp`. Version affichée : **2.12.0**.
+- La page garde une requête GET « pending » perpétuelle → les outils attendant `document_idle`
+  (screenshot, get_page_text, read_page, find) **échouent** ; seul `javascript_tool` fonctionne.
+- Boutons (`input type=button` toolbar, sprites) : `element.click()` et la soumission de formulaire
+  forcée **ne marchent pas** (handlers du framework). Ce qui marche : **séquence de `MouseEvent`
+  réels** `mousedown`/`mouseup`/`click` (bubbles) sur l'élément (bouton-toolbar, ligne de tableau,
+  label d'onglet).
+- Liens (`<a>`) : `a.click()` fonctionne. **`history.back()` interdit** (casse l'état JSF —
+  re-naviguer depuis l'URL d'entrée). Boutons toolbar utiles : `[title="Lancer la recherche"]`,
+  `[title="Retour à l'écran de liste"]`, `[title="Retour à l'écran de recherche"]`.
+- Recherche : sélectionner `form0:i_anneeScolaire` **et** `form0:i_nsFaseIdImpl` (implantation)
+  avant de lancer.
+- Les pages contiennent des données personnelles (matricules/noms enseignants, liste
+  `lstEnseignant`) → n'extraire que des **structures** (en-têtes, options de référentiels).
+- Étabissement affiché « 3052 - 9017001 » = matricule EPS - matricule FASE ; implantation
+  « 6050 - 0 - adresse ».
+
+## 4. Points restants
+
+- Confirmer le mapping lettre↔libellé de `teStatut` par un appel SOAP `LireDocument3` (les lettres
+  ne sont pas visibles dans l'UI, seulement les libellés).
+- Ligne 97 « PERIODES S… » : libellé tronqué à l'écran (vraisemblablement « périodes
+  supplémentaires », catégorie `PeSu`) — à confirmer.
+- Tester une organisation **avec** intervention extérieure (colonne IE = `I` dans la liste) pour
+  voir l'onglet IE rempli.
+- Le test TQ du déclencheur `20102` reste à faire côté SOAP (l'UI ne permet pas de le simuler sans
+  modifier des données).

--- a/specs/21_calcul_encadrement_dotation.md
+++ b/specs/21_calcul_encadrement_dotation.md
@@ -1,0 +1,278 @@
+# Calcul de l'encadrement et de la dotation de périodes (Enseignement pour Adultes / Promotion sociale)
+
+> Spécification fonctionnelle « financement » — comment les chiffres récupérables via les services
+> EPROM/SEPS se transforment en **encadrement** (équipe) et en **dotation de périodes** (rémunération des enseignants).
+> Sources : décret du 16/04/1991 (coordonné) + arrêtés + circulaires « PS » recensées par la circulaire-répertoire **2816 du 13/07/2009** ; circulaires calendrier/DI/renseignements déjà analysées (specs 16-19) ; apport métier de l'utilisateur.
+> Date d'analyse : 2026-06-10 (session 9bis — mise à jour avec le décret coordonné)
+>
+> ✅ **Statut** : **complet et confirmé verbatim**. (1) **Décret coordonné du 16/04/1991** (`circulaires/16184_0036.pdf`,
+> MAJ Gallilex 19/12/2025) — dotation, périodes-élèves, catégories, norme d'autonomie. (2) **Arrêté GCF du 22/11/2002**
+> « fixant les règles des ajustements des dotations de périodes dans l'Enseignement pour Adultes » (numac `2003029045`,
+> **version coordonnée Justel MAJ 18/08/2025**) — **table de pondération et mécanisme d'ajustement** (art. 3-4).
+> → la chaîne de calcul est désormais entièrement spécifiée ; il ne reste plus de 🔶 bloquant.
+
+---
+
+## 1. Les deux grandeurs à ne pas confondre
+
+| Grandeur | Ce qu'elle finance | Base de calcul |
+|---|---|---|
+| **Encadrement** | l'**équipe** (personnel **administratif**, direction, auxiliaire d'éducation) | les **périodes-élèves (PE)** |
+| **Dotation de périodes** | les **périodes à consommer pour rémunérer les enseignants** (chargés de cours) | les **périodes-élèves *pondérées*** (coefficients par catégorie) |
+
+> C'est la distinction structurante (confirmée par l'utilisateur). Les **mêmes périodes-élèves** servent de base aux deux, mais la **dotation applique une pondération** que l'encadrement n'applique pas.
+
+Deux principes temporels/financiers (specs 17 & 19) :
+- La **dotation de périodes** est une **enveloppe attribuée chaque juillet pour l'année civile suivante** → gestion **par année civile** (découpage 16 semaines 2025 + 24 semaines 2026 = 40 semaines numérotées, spec 17). D'où la **ventilation par année civile** des périodes du Doc 2 (spec 04).
+- Les périodes des **dossiers pédagogiques** des UE organisées sont **prélevées** sur la dotation (décret art. 82-93, 102).
+
+---
+
+## 2. Cadre légal et réglementaire
+
+| Texte | Objet | Spec liée |
+|---|---|---|
+| **Décret 16/04/1991 (coordonné 19/12/2025), art. 82-93, 99-102** | ✅ **dotations de périodes** (ch. II) et **périodes-élèves** (art. 99) — base légale confirmée verbatim | — |
+| Décret 30/06/1998, art. 55 | encadrement différencié / discriminations positives | — |
+| **Arrêté GCF 22/11/2002** (numac 2003029045, coord. 18/08/2025) | ✅ **règles des ajustements** + **table de pondération** (art. 1-7) — délégué par l'art. 87 du décret | — |
+| **Arrêté GCF 09/07/2004, art. 7** | dossiers pédagogiques → **part d'autonomie** (cf. décret art. 8/137 : « part d'autonomie de l'horaire de référence minimum ») 🔶 | — |
+| Arrêté GCF 20/07/1993 | dédoublements et regroupements (min. 1 élève, régime 1) | spec 19 |
+| Décrets « diverses mesures » 09/02/2017, 14/11/2018, 20/07/2022 | modifications EPS/EA (état courant) 🔶 | — |
+| **Circulaire PS 327/96** | **calcul des périodes-élèves** + cas particuliers (encadrement stages, épreuve intégrée, alternance) 🔶 | — |
+| **Circulaire PS 402/03** | nouvelles règles des **ajustements** des dotations de périodes 🔶 | — |
+| Circulaires PS 357/98 & PS 422/06 | conseil des études, part supplémentaire, périodes supplémentaires, **expertise pédagogique et technique** | spec 19 (lignes 95/96) |
+| Circulaire **5447 (2015)** + dossiers pédagogiques | **part d'autonomie ≈ 20 %** | — |
+| Circulaire-répertoire **2816 (13/07/2009)** | recense l'ensemble des dispositions PS (vade-mecum) | — |
+| Circulaires **8684** (renseignements annuels), **9487** (calendrier/dotation), DI **9217/9488/9731** | mise en œuvre annuelle | specs 19, 17, 16 |
+
+> Terminologie : depuis 2025, l'« enseignement de promotion sociale » est dénommé **« Enseignement pour Adultes »** ; le décret du 16/04/1991 est désormais intitulé « organisant l'enseignement pour adultes ». Les textes « PS » historiques restent la référence opérationnelle jusqu'à refonte.
+
+---
+
+## 3. Périodes-élèves (PE) — l'assiette commune
+
+**Formule légale — décret art. 99 (✅ verbatim)** :
+
+```
+PE(UE)          = nombre de périodes de l'UE réellement organisées durant l'année civile
+                  × nombre d'élèves réguliers concernés
+PE(établissement) = Σ PE(UE ou parties d'UE réellement organisées durant l'année civile)
+```
+> Donc : produit **périodes réellement organisées × élèves réguliers**, sommé sur toutes les UE. La base
+> est l'**année civile** (cohérent avec la gestion de la dotation par année civile, §1) et les périodes
+> **réellement organisées** (pas seulement planifiées).
+
+**Norme de rationalisation (art. 98, 100, 101 — à ne pas confondre avec la « part d'autonomie » du §4)** :
+chaque établissement autonome doit générer un **minimum de périodes-élèves** : **30 000 PE** (siège dans un
+arrondissement < 125 hab/km²) ou **40 000 PE** (autres cas). En-dessous au 31/12, l'établissement **perd son
+autonomie** au 1er janvier suivant (fusion ou fermeture). C'est ici le sens « autonomie **de l'établissement** ».
+
+- **Étudiants réguliers comptabilisés** : déterminés par les règles de comptage aux **1ᵉʳ/10ᵉ et 5ᵉ/10ᵉ** (circulaire 9593, spec 14) → matérialisés par `regulier1`/`regulier5` côté SEPS (spec 11). CM (certificat médical) assimilé à présence ; dispense complète = exclu.
+- **Périodes de l'UE** : périodes du **dossier pédagogique** (Doc 8bis, `nbPeriodesDoc8`), **part d'autonomie comprise** (cf. §4).
+- **Exclusion** : les étudiants **redevables du droit d'inscription non en ordre de paiement** ne sont **pas** pris en compte pour l'encadrement, l'**ajustement de la dotation**, ni les subventions de fonctionnement (specs 16 & 19).
+
+### Cas particuliers (comptés à part — PS 327/96 ; specs 19)
+| Cas | Règle de calcul (spec 19) |
+|---|---|
+| Encadrement de **stage** / **épreuve intégrée** | col. 18+19 = **col. 14 × périodes prévues par étudiant** |
+| Périodes **réservées** (cas particuliers) | **périodes réservées × nombre moyen de PE par période organisée** (arrondi 2ᵉ décimale) |
+| **Interventions extérieures (IE)** | **comptent pour les PE** (encadrement) mais **n'entrent pas dans l'ajustement** de la dotation |
+| Suivi pédagogique (ligne 96), expertise pédagogique/technique (ligne 95), périodes supplémentaires, valorisation des acquis (VA), conseil des études, milieu carcéral / e-learning | régimes spécifiques (lignes 91-96, PS 357/98 / 422/06) 🔶 |
+
+---
+
+## 4. Part d'autonomie (≈ 20 %)
+
+> ⚠️ **Deux « autonomie » distinctes** : (a) ici, la **part d'autonomie de l'horaire de référence** d'une UE
+> (notion de **dossier pédagogique**) ; (b) au §3, la **norme d'autonomie de l'établissement** (30 000/40 000 PE,
+> art. 100-101). Sans rapport l'une avec l'autre.
+
+Le décret (art. 8 et 137 ; compétence du Conseil général) prévoit « la fixation de la **part d'autonomie de
+l'horaire de référence minimum** et de la **part supplémentaire maximale** de l'horaire de référence des unités
+d'enseignement […] qui peut être utilisée par chaque établissement **sans modifier la certification** obtenue sur
+la base du dossier de référence minimum ». Le **dossier pédagogique** fixe donc le nombre **minimum** de périodes
+par cours **et** cette part d'autonomie ; elle **correspond généralement à ≈ 20 %** du total des périodes (valeur
+issue des dossiers / arrêté 09/07/2004 art. 7 ; circ. 5447 — 🔶 taux exact à confirmer par dossier).
+
+- La part d'autonomie **entre dans le total des périodes** de l'UE → donc dans les **PE** et dans la **consommation de dotation**, mais son emploi est **à la main de l'établissement**.
+- Lien horaire (spec 17) : l'horaire doit couvrir **100 %** des périodes du dossier pédagogique (autonomie comprise), avec **≥ 90 %** effectivement dispensées.
+
+---
+
+## 5. De l'assiette aux deux résultats
+
+### 5.1 Encadrement (équipe administrative)
+Calculé directement sur les **PE** (cas généraux + particuliers), sans pondération de catégorie. Sert à déterminer les charges du **personnel administratif / direction / auxiliaire d'éducation** (décret art. 35 pour le comptage des étudiants réguliers ; art. 82-93 pour l'encadrement). 🔶 (paramètres/seuils exacts à confirmer).
+
+### 5.2 Dotation de périodes (rémunération des enseignants)
+
+**Unité & catégories (✅ décret)** : la dotation est exprimée en **périodes de 50 minutes** (art. 82, « périodes
+organiques »). Chaque période appartient à une **catégorie** (art. 83 §1) — c'est l'**axe de pondération** :
+
+| Catégorie | Périmètre |
+|---|---|
+| **A** | enseignement **secondaire supérieur** (EA) |
+| **B** | enseignement **secondaire inférieur** (EA) |
+| **C** | enseignement de **niveau supérieur** (EA) |
+
+> Dotation **attribuée par année civile** (art. 86). L'art. 87 délègue les règles d'ajustement à l'**arrêté GCF du
+> 22/11/2002** (✅ ci-dessous).
+
+#### Périodes-élèves **pondérées** (arrêté 22/11/2002, art. 3-4 — ✅ verbatim)
+
+```
+PE pondérées(cours) = périodes-élèves(cours) × coefficient pédagogique × coefficient de niveau
+```
+
+**Coefficient pédagogique** (art. 3, 1°, a) :
+| Valeur | Cours concernés |
+|---|---|
+| **1** | cours généraux ; cours techniques (industriels et non-industriels) ; cours spéciaux ; psychopédagogie et méthodologie |
+| **1,6** | cours généraux de remise à niveau / méthodologie spéciale ; cours techniques de méthodologie spéciale ; travaux de labo (ind./non-ind.) ; pratique professionnelle **non** industrielle ; cours techniques et de pratique professionnelle ; cours spéciaux de dactylographie |
+| **2,8** | pratique professionnelle **industrielle** ; pratique professionnelle de **nursing** |
+
+**Coefficient de niveau** (art. 3, 1°, b) — ⚠️ catégories de l'art. 83 du décret + une **catégorie D** maintenue dans le barème :
+| Catégorie | Coefficient |
+|---|---|
+| **B** (secondaire inférieur) | **1** |
+| **A** (secondaire supérieur) | **1,25** |
+| **C** (supérieur) | **1,5** |
+| **D** | **1,8** *(⚠️ « D » abrogé du décret en 2021 mais toujours présent au barème de l'arrêté — à clarifier)* |
+
+**Définition des assiettes (art. 1)** :
+- **Cas généraux** = périodes des cours du dossier pédagogique **hors part d'autonomie et hors encadrement**.
+- **Cas particuliers** = encadrement, périodes supplémentaires, valorisation des acquis (formels/informels/non-formels),
+  suivi pédagogique, conseil des études, expertise pédagogique/technique (+ **carcéral / e-learning** assimilés).
+- **Périodes prévues** = déclarées par l'établissement ; **périodes réelles** = déclarées et réellement utilisées.
+
+**Calcul des PE pondérées d'un établissement (art. 4, procédure en 6 étapes)** :
+1. **Cas généraux** : cours par cours, PE pondérées générées par les **périodes prévues** de l'**avant-dernière année
+   civile** (art. 2).
+2. **Part d'autonomie** : on ajoute ses PE pondérées — la part d'autonomie se **répartit au prorata des autres cours**
+   du dossier pédagogique.
+3. **Limitation « organique »** : réduction au prorata des périodes **ne provenant pas** de la dotation de l'établissement
+   → PE pondérées **organiques** par formation, totalisées.
+4. **Cas particuliers** : ajout sur la base du **nombre moyen de PE pondérées par période** des activités hors cas
+   particuliers. → chaque période d'un cas particulier « vaut » la **moyenne PE pondérées/période** de l'établissement.
+   - **EPT = Expertise Pédagogique et Technique** (cas particulier ; = flag `organisationPeriodesSupplOuEPT` spec 02,
+     case « périodes suppl./EPT » spec 19, préfixe `EPT` sur l'EA12 spec 08 — **≠ épreuve intégrée**) :
+     `PE pondérées(EPT) = périodes réelles organiques d'EPT × moyenne PE pondérées/période`. Volume : **40-800 périodes**
+     par activité, 1,8 h/période (décret art. 91/4) ; plafond **10 %** de la dotation organique avec les autres
+     activités hors cours (art. 91/6).
+   - *Valorisation des acquis non-formels/informels → 10 % des périodes prévues de l'UE.*
+5. **Neutralisation** des augmentations ponctuelles de dotation.
+6. **Corrections pour dépassements** (périodes utilisées au-delà des périodes utilisables).
+
+#### Mécanisme d'ajustement (arrêté 22/11/2002, art. 3 §2 et art. 5-7)
+- **Dotation de référence** = dotation de l'**année précédente** (art. 1, h). On compare les **PE pondérées** de
+  l'avant-dernière année civile aux **PE pondérées de référence**.
+- **Intervalle de neutralisation ±8 %** (art. 3, 2° ; art. 5) : dans l'intervalle → dotation **inchangée** ; en-deçà →
+  **baisse** ; au-delà → **hausse** (seulement si les baisses dégagent du disponible — enveloppe fermée).
+- **Baisse** (art. 6) : réduction = **¼ de la dotation × |% de baisse|**, **plafonnée à 50 périodes** ; le total
+  récupéré est **redistribué** aux établissements en hausse, au prorata des PE pondérées gagnées.
+- **Enveloppe globale** (art. 7) : le % de variation de la dotation globale est appliqué à chaque établissement.
+- **Délai** (art. 2) : documents de calcul à l'Administration dans **35 jours calendrier** à compter du 1ᵉʳ dixième.
+
+> Catégories/cours lisibles côté Doc 2 via `coCategorie`/`coCatCol` (spec 04) → c'est l'entrée de la pondération.
+
+**Déductions (✅ art. 87bis)** : périodes hors horaire approuvé, périodes prévues mais non enseignées (sans dispense
+régulière), prestations rémunérées non déclarées, ouvertures antérieures à l'autorisation (+ pertes de charge /
+disponibilités) — déduites **sans** ajustement.
+
+**Réserve & dépassement (✅ art. 91 et 93)** : `réserve = dotation/école − périodes utilisées`, jamais **négative**.
+Tout dépassement → l'année civile suivante, **réduction de 1,5×** le dépassement (puis coefficient correcteur la 2ᵉ
+année, réintégration la 3ᵉ).
+
+**Plafonds activités hors cours (✅ art. 91/6 et 91/4)** : conseil des études, suivi pédagogique, admission/sanction,
+**expertise pédagogique et technique**, activités de formation consomment la dotation, dans la limite de **10 % de la
+dotation organique** (art. 82) — dont **≤ 1 %** pour les seules activités de formation. Une activité d'expertise =
+**40 à 800 périodes** (1,8 h/période).
+
+**Supplément « suivi pédagogique » (✅ art. 36 §2)** — en **périodes B**, selon les **périodes-élèves générées**
+(⚠️ corrige la table provisoire antérieure, qui était erronée) :
+
+| Périodes-élèves générées | Supplément (périodes B) |
+|---|---|
+| 30 000 – 119 999 | **100** |
+| 120 000 – 239 999 | **200** |
+| 240 000 – 359 999 | **300** |
+| 360 000 – 499 999 | **400** |
+| ≥ 500 000 | **500** |
+
+(+ enveloppe **9 600 périodes B** pour les conseillers pédagogiques EA, répartie au prorata — art. 36bis.)
+
+**Consommation** : les **attributions** aux enseignants (Doc 3, `nbPeriodesAttribuees`) consomment la dotation et sont
+**plafonnées** par les périodes organisées (Doc 2 + IE) — erreurs `1538`/`1574`/`1575`/`1576` (spec 05).
+
+---
+
+## 6. Chaîne de calcul ↔ services (récupérable par pyetnic)
+
+```
+SEPS Inscriptions (spec 11-12)            EPROM Doc 1 / 1D (spec 03/06)
+  regulier1/regulier5, fse,                 nbEleve* (1/10ᵉ), nbEleves5ieme (5/10ᵉ),
+  droitInscription (payé ?)                  DI / motif exemption
+        │                                            │
+        └─────────────┬──────────────────────────────┘
+                      ▼
+         Étudiants réguliers comptabilisés  ── (DI non payé → exclu)
+                      │
+   Doc 2 (spec 04) ───┤  périodes par UE (prévues/réelles, par année civile),
+   Doc 8bis ──────────┤  catégories CG/CT/PP/CS (coCategorie), IE, part d'autonomie
+                      ▼
+              PÉRIODES-ÉLÈVES (PE)  = Σ (périodes UE × étudiants) + cas particuliers
+                ├────────────────────────────► ENCADREMENT (équipe)        [PE]
+                └──(× coefficients de catégorie)► DOTATION DE PÉRIODES       [PE pondérées]
+                                                   │  + supplément par tranches de PE
+                                                   │  − ajustement (population réelle, DI exclus)
+                                                   ▼
+                            Doc 3 (spec 05) : attributions enseignants ≤ dotation (consommation)
+```
+
+---
+
+## 7. Faisabilité pyetnic
+
+**Récupérable / calculable** :
+- Tous les **intrants** : populations (Doc 1/1D), périodes et catégories (Doc 2, Doc 8bis), attributions (Doc 3), inscriptions individuelles + statut régulier + FSE + DI (SEPS).
+- Le **comptage** des étudiants réguliers (règles 1/10ᵉ-5/10ᵉ) et donc les **périodes-élèves** (cas généraux ; cas particuliers stage/épreuve intégrée via col. 14).
+- ✅ Le **calcul complet** des **PE pondérées** (coefficients pédagogiques 1/1,6/2,8 × coefficients de niveau B/A/C/D) et le **mécanisme d'ajustement** (±8 %, baisse plafonnée, redistribution) — formule désormais entièrement spécifiée (décret art. 99 + arrêté 22/11/2002 art. 3-4).
+
+**Non disponible via les web services** :
+- La **dotation de base / dotation de référence** (enveloppe de l'année précédente) — **communiquée par l'administration** (juillet, par année civile), historiquement consultée via le système hôte **HOD/CICS « pot K » (écran 59)**, hors API (spec 19). C'est le **seul intrant non récupérable** par service.
+
+**Conclusion** : pyetnic peut désormais **reproduire le calcul** — périodes-élèves, **pondération** (table embarquée), encadrement, consommation, contrôle 90 %/100 %, plafonds Doc 3 — et **estimer la dotation** dès lors qu'on lui fournit la **dotation de référence** (saisie) et qu'on neutralise l'effet « enveloppe fermée » (l'ajustement inter-établissements ±8 % dépend des autres écoles, donc une **estimation par établissement** est exacte *à la dotation de référence + variation d'enveloppe près*). La **valeur officielle** reste celle de l'administration. Un module « financement » paramétrable par **millésime** (coefficients, ±8 %, plafond 50, plafonds 10 %/1 %) est recommandé, séparé du client SOAP.
+
+---
+
+## 8. Points à confirmer (verbatim, sur les textes)
+
+✅ **Confirmé verbatim** — décret coordonné (`16184_0036.pdf`, MAJ 19/12/2025) **et** arrêté GCF 22/11/2002
+(numac `2003029045`, coord. 18/08/2025) :
+- **PE** = périodes réellement organisées × élèves réguliers (décret art. 99) ; **catégories A/B/C** (art. 83) ;
+  norme **30 000/40 000 PE** (art. 100) ; période **50 min** (art. 82) ; dotation **par année civile** (art. 86) ;
+  **déductions** (art. 87bis) ; **réserve + dépassement 1,5×** (art. 91/93) ; **plafond 10 %** activités hors cours,
+  **≤ 1 %** formation (art. 91/6) ; expertise **40-800 périodes** (art. 91/4) ; supplément suivi pédagogique
+  100-500 périodes B (art. 36 §2).
+- **Pondération** : coefficient pédagogique **1 / 1,6 / 2,8** × coefficient de niveau **B=1 / A=1,25 / C=1,5 / D=1,8** ;
+  **cas généraux / part d'autonomie / cas particuliers** ; calcul des PE pondérées en 6 étapes ; **neutralisation ±8 %** ;
+  baisse plafonnée à **50 périodes** (¼ × |%|) ; redistribution au prorata (arrêté art. 1-7).
+
+Restent ouverts (mineurs, **non bloquants**) :
+1. 🔶 **Catégorie « D » du barème** (coef. niveau 1,8) : présente dans l'arrêté mais le « D » a été **abrogé de
+   l'art. 83 du décret en 2021** → clarifier ce que recouvre encore « D » (sortie en voie d'extinction ?).
+2. 🔶 **Arrêté GCF du 09/07/2004** (dossiers pédagogiques, art. 7) : **taux exact** de la part d'autonomie (≈ 20 %).
+   Gallilex `textes-normatifs/40726` (à confirmer) ; circ. **5273**/**5447**.
+3. 🔶 **Modèle d'annexe** de l'arrêté 22/11/2002 (documents administratifs de calcul, art. 2) : utile pour le mapping
+   exact avec les colonnes des Doc 1/2 (déjà largement couvert par les specs 19 et 20).
+4. ✅ **Actualisation EA** : décret coordonné 19/12/2025 et arrêté coordonné 18/08/2025 — **tous deux à jour**.
+
+---
+
+## Sources
+- [Circulaire 2816 du 13/07/2009 — répertoire des dispositions PS (recense décret art. 82-93, arrêté 22/11/2002, PS 327/96, PS 402/03)](http://www.enseignement.be/upload/circulaires/000000000002/3023_20090715153104.pdf)
+- **Décret du 16/04/1991 (coordonné, MAJ 19/12/2025)** — déposé localement : `circulaires/16184_0036.pdf` (71 p.) — articles 82-93, 99-102 (source verbatim de cette spec). Page Gallilex : https://gallilex.cfwb.be/textes-normatifs/16184
+- **Arrêté GCF du 22/11/2002 (coordonné, MAJ 18/08/2025)** — règles d'ajustement + **table de pondération** (art. 1-7), source verbatim §5.2. [Justel](https://www.ejustice.just.fgov.be/eli/arrete/2002/11/22/2003029045/justel) · [PDF consolidé](https://www.ejustice.just.fgov.be/img_l/pdf/2002/11/22/2003029045_F.pdf) (à déposer dans `circulaires/` si souhaité).
+- [Enseignement.be — dossiers pédagogiques / part d'autonomie (circ. 5447/2015)](https://gallilex.cfwb.be/sites/default/files/imports/41427_000.pdf)
+- [Circulaire 4903 du 26/06/2014 — DI (redevables non payés exclus du calcul de l'encadrement / ajustement de la dotation)](https://gallilex.cfwb.be/sites/default/files/imports/39963_000.pdf)
+- Specs internes liées : `04_formation_periodes_v1.md`, `05_document3_v1.md`, `06_formation_droits_inscription_v1.md`, `16_circulaires_droit_inscription.md`, `17_circulaire_9487_calendrier_dotation.md`, `19_circulaire_8684_renseignements_annuels.md`.


### PR DESCRIPTION
## Summary

Two documentation batches:

**Specs enrichment (previous sessions)**
- specs 16-21: circulaires droit d'inscription, 9487 (calendrier dotation), 8829 (hybride), 8684 (renseignements annuels), EPROM UI exploration, encadrement/dotation reference
- `rapport_referentiels_doc3.md`: read-only referential audit of LireDocument3 (TQ, 123 organisations)
- `docs/AUDIT.md`: post-0.0.12 addendum (D7: `nbPeriodes*` typed `float` vs `xs:int` in XSD)

**Full-scale production tests (2026-06-11)**
- Opened organisations 328, 537 and the 510 two-school-year continuation on 2026-2027
- `rapport_test_prod_organisation_328.md`: test log — error 20030 bounds anticipation only (J+3m4d accepted, J+4m22d rejected, J-3m accepted); D2 None-stripping clean on create; `implId=None` gotcha reproduced; dixième dates absent from the SOAP model
- specs/02: observed semantics of two-school-year organisations (both records carry full dates; head has `numOrganisation2AnneesScolaires=0`, tail points to the head)
- specs/19: 20030 boundary measurements added to the open point
- `docs/ARCHITECTURE.md`: new **Scope Boundary** section — pyetnic is a contract-fidelity layer; business knowledge lives in docs, business logic stays in consuming applications

Documentation only, no code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)