### PR TITLE
docs: PE/PEP financing chain calibrated against official host reports (session 9ter)

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -7,5 +7,13 @@ These are operational scripts written during development. They demonstrate real-
 - **`extrait_profs.py`** — extracts the list of teachers from Document 3 for a given school year.
 - **`print_doc2.py`** — prints a formatted view of Document 2 (periods of teaching activity).
 - **`print_doc3.py`** — prints a formatted view of Document 3 (teacher assignments).
+- **`calcul_pep_annee_civile.py`** — computes the weighted student-periods (PEP, dotation
+  assessment base) of a civil year and writes a markdown report. Validated at +0.46 % against
+  the official host figures for 2025 (see `specs/21_calcul_encadrement_dotation.md`).
+- **`calcul_pe_encadrement.py`** — estimates the raw student-periods (PE, staffing side) of a
+  civil year. Validated at ±1 % against the official host figures for 2025.
+
+The two financing scripts are demonstrations, not a supported API: by design the financing
+engine lives **outside** pyetnic (spec 21 §7) — pyetnic stays a faithful SOAP client.
 
 These scripts require a valid `.env` with ETNIC credentials. Adapt `etab_id`, `num_adm_formation`, etc. to your own establishment.

--- a/examples/calcul_pe_encadrement.py
+++ b/examples/calcul_pe_encadrement.py
@@ -1,0 +1,92 @@
+"""Estimate the raw student-periods (PE, "encadrement" side) of a civil year.
+
+Demonstration script (the financing engine is intentionally kept out of pyetnic).
+Validated at ±1 % against the host screen 57D for civil year 2025 (session 9ter).
+
+Rule (reconstructed and validated against official figures):
+  PE = sum(periods x students) over every line carrying students — external
+       interventions included —
+     + (reserved organic periods + IE periods without students) x average PE/period
+
+The residual ±1 % stems from the valuation rule of student-less IE sessions
+(VC/convention) and from unpaid registration-fee exclusions, both out of API reach.
+
+Usage: python calcul_pe_encadrement.py 2025
+"""
+
+import argparse
+import logging
+
+from pyetnic.eprom import lire_document_2, lister_formations
+
+
+def collecter(annee_scolaire, attr_act, attr_ie):
+    out = []
+    for formation in lister_formations(annee_scolaire=annee_scolaire):
+        for apercu in formation.organisations:
+            doc2 = lire_document_2(apercu.id)
+            det = doc2.activiteEnseignementDetail if doc2 else None
+            lignes = det.activiteEnseignementListe.activiteEnseignement if det and det.activiteEnseignementListe else []
+            ie = 0.0
+            if doc2 and doc2.interventionExterieureListe:
+                for inter in doc2.interventionExterieureListe.interventionExterieure:
+                    if inter.periodeListe:
+                        ie += sum(getattr(p, attr_ie) or 0.0 for p in inter.periodeListe.periode)
+            out.append({
+                "eleves_max": max((l.nbEleveC1 or 0 for l in lignes), default=0),
+                "lignes": [(l.nbEleveC1 or 0, getattr(l, attr_act) or 0.0) for l in lignes],
+                "ie": ie,
+            })
+    return out
+
+
+def calculer(annee_civile):
+    orgs = collecter(f"{annee_civile - 1}-{annee_civile}", "nbPeriodeReelleAn2", "nbPerAn2") + \
+        collecter(f"{annee_civile}-{annee_civile + 1}", "nbPeriodeReelleAn1", "nbPerAn1")
+
+    pe_eleves = per_eleves = 0.0   # organic lines carrying students
+    per_reservees = 0.0            # organic lines without students (EPT, etc.)
+    pe_ie = per_ie = 0.0           # IE periods of organisations WITH students
+    per_ie_sans_eleves = 0.0       # IE periods of organisations WITHOUT students
+
+    for o in orgs:
+        for eleves, per in o["lignes"]:
+            if per <= 0:
+                continue
+            if eleves > 0:
+                pe_eleves += per * eleves
+                per_eleves += per
+            else:
+                per_reservees += per
+        if o["ie"] > 0:
+            if o["eleves_max"] > 0:
+                pe_ie += o["ie"] * o["eleves_max"]
+                per_ie += o["ie"]
+            else:
+                per_ie_sans_eleves += o["ie"]
+
+    moyenne = (pe_eleves + pe_ie) / (per_eleves + per_ie) if (per_eleves + per_ie) else 0.0
+    pe_moyenne = (per_reservees + per_ie_sans_eleves) * moyenne
+    return {
+        "pe_eleves": pe_eleves, "pe_ie": pe_ie, "pe_moyenne": pe_moyenne,
+        "per_reservees": per_reservees, "per_ie_sans_eleves": per_ie_sans_eleves,
+        "moyenne": moyenne, "total": pe_eleves + pe_ie + pe_moyenne,
+    }
+
+
+def main():
+    parser = argparse.ArgumentParser(description="PE (encadrement) estimate for a civil year (read-only).")
+    parser.add_argument("annee_civile", type=int, help="civil year, e.g. 2025")
+    args = parser.parse_args()
+
+    logging.basicConfig(level=logging.WARNING)
+    r = calculer(args.annee_civile)
+    print(f"PE lignes avec élèves (IE comprises) : {r['pe_eleves'] + r['pe_ie']:12.1f}")
+    print(f"périodes réservées + IE sans élèves  : {r['per_reservees'] + r['per_ie_sans_eleves']:12.1f}"
+          f"  × moyenne {r['moyenne']:.3f} = {r['pe_moyenne']:.1f}")
+    print(f"PE TOTAL (encadrement) {args.annee_civile}        : {r['total']:12.1f}")
+    print("(estimation ±1 % — IE sans élèves valorisées à la moyenne, DI non payés non exclus)")
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/calcul_pep_annee_civile.py
+++ b/examples/calcul_pep_annee_civile.py
@@ -1,0 +1,227 @@
+"""Compute the weighted student-periods (PEP) of a civil year and write a markdown report.
+
+This is a demonstration script, not a supported API: the financing engine is
+intentionally kept OUT of pyetnic (see specs/21_calcul_encadrement_dotation.md §7).
+It reproduces the official dotation assessment base (validated at +0.46 % against
+the host screen 55L for civil year 2025, session 9ter).
+
+Method — arrete GCF 22/11/2002 art. 3-4:
+  1. general cases: PE x pedagogical coefficient x level coefficient, line by line
+  2. autonomy share: prorated on the course structure of the *dossier pedagogique*
+     (nbPeriodeBranche), NOT on the civil-year slice (two-school-year organisations)
+  3. organic limitation: the Doc 2 "real" columns only carry the dotation share
+     (external interventions live in their own block) — confirmed by host report 4
+  4. particular cases (EPT, supervision, follow-up): periods x average PEP/period
+
+Civil year N = An2 real periods of school year N-1/N + An1 real periods of N/N+1.
+
+Usage: python calcul_pep_annee_civile.py 2025 [-o rapport.md]
+"""
+
+import argparse
+import csv
+import logging
+import re
+from datetime import date
+from pathlib import Path
+
+from pyetnic.eprom import lire_document_2, lire_organisation, lister_formations
+
+CSV_PATH = Path(__file__).resolve().parents[1] / "specs/referentiels/coefficients_ponderation_coCategorie.csv"
+
+NIVEAU = {"1": ("B", 1.0), "2": ("A", 1.25), "3": ("C", 1.5)}
+
+
+def charger_bareme():
+    coef_ped, groupe = {}, {}
+    with open(CSV_PATH, newline="", encoding="utf-8") as f:
+        for row in csv.DictReader(f):
+            groupe[row["code"]] = row["groupe"]
+            if row["coef_pedagogique"]:
+                coef_ped[row["code"]] = float(row["coef_pedagogique"])
+    return coef_ped, groupe
+
+
+def coef_niveau(code_formation):
+    m = re.search(r"U(\d)\d", code_formation or "")
+    if m and m.group(1) in NIVEAU:
+        return NIVEAU[m.group(1)]
+    return (None, None)
+
+
+def collecter(annee_scolaire, attr_reel_civil):
+    """Read every Doc 2 of a school year; attr_reel_civil selects the civil-year column."""
+    out = []
+    for formation in lister_formations(annee_scolaire=annee_scolaire):
+        for apercu in formation.organisations:
+            org = lire_organisation(apercu.id)
+            doc2 = lire_document_2(apercu.id)
+            lignes = []
+            if doc2 and doc2.activiteEnseignementDetail and doc2.activiteEnseignementDetail.activiteEnseignementListe:
+                lignes = doc2.activiteEnseignementDetail.activiteEnseignementListe.activiteEnseignement
+            out.append({
+                "annee": annee_scolaire,
+                "num_adm": formation.numAdmFormation,
+                "code": formation.codeFormation,
+                "libelle": formation.libelleFormation,
+                "num_org": apercu.id.numOrganisation,
+                "flag_ie": org.typeInterventionExterieure if org else None,
+                "lignes": [
+                    {"cat": l.coCategorie, "nom": l.teNomBranche,
+                     "eleves": l.nbEleveC1 or 0, "per": getattr(l, attr_reel_civil) or 0.0,
+                     "branche": l.nbPeriodeBranche or 0.0}
+                    for l in lignes
+                ],
+            })
+    return out
+
+
+def calculer(annee_civile):
+    coef_ped, groupe = charger_bareme()
+    orgs = collecter(f"{annee_civile - 1}-{annee_civile}", "nbPeriodeReelleAn2") + \
+        collecter(f"{annee_civile}-{annee_civile + 1}", "nbPeriodeReelleAn1")
+
+    lignes_ue, avertissements, cas_particuliers, a_confirmer = [], [], [], []
+    tot_pe_gen = tot_pep_gen = tot_per = 0.0
+    tot_pe_auto = tot_pep_auto = 0.0
+
+    for o in orgs:
+        niv, c_niv = coef_niveau(o["code"])
+        gen = [l for l in o["lignes"] if groupe.get(l["cat"]) == "cas_general" and l["per"] > 0]
+        auto = [l for l in o["lignes"] if groupe.get(l["cat"]) == "autonomie" and l["per"] > 0]
+        part = [l for l in o["lignes"] if str(groupe.get(l["cat"], "")).startswith("cas_particulier") and l["per"] > 0]
+        conf = [l for l in o["lignes"] if groupe.get(l["cat"]) == "a_confirmer" and l["per"] > 0]
+        inconnues = [l for l in o["lignes"] if l["cat"] not in groupe and l["per"] > 0]
+
+        if not (gen or auto or part or conf or inconnues):
+            continue
+        if c_niv is None and (gen or auto):
+            avertissements.append(f"{o['annee']} {o['num_adm']}/org{o['num_org']} : niveau introuvable dans `{o['code']}`")
+            continue
+
+        pe_g = pep_g = per_g = 0.0
+        for l in gen:
+            pe = l["per"] * l["eleves"]
+            pe_g += pe
+            pep_g += pe * coef_ped[l["cat"]] * c_niv
+            per_g += l["per"]
+            if l["eleves"] == 0:
+                avertissements.append(
+                    f"{o['annee']} {o['num_adm']}/org{o['num_org']} : {l['per']:g} pér. réelles sans élèves ({l['cat']})"
+                )
+
+        # Autonomy prorata base = dossier pedagogique structure (nbPeriodeBranche)
+        dossier = [l for l in o["lignes"] if groupe.get(l["cat"]) == "cas_general" and l["branche"] > 0]
+        branche_tot = sum(l["branche"] for l in dossier)
+        pe_a = pep_a = 0.0
+        for l in auto:
+            if branche_tot > 0:
+                c_moyen = sum(x["branche"] * coef_ped[x["cat"]] for x in dossier) / branche_tot * c_niv
+                pe_a += l["per"] * l["eleves"]
+                pep_a += l["per"] * l["eleves"] * c_moyen
+            else:
+                avertissements.append(
+                    f"{o['annee']} {o['num_adm']}/org{o['num_org']} : AUTO {l['per']:g} pér. sans cas généraux au dossier → non comptées"
+                )
+
+        cas_particuliers.extend((o, l) for l in part)
+        a_confirmer.extend((o, l) for l in conf)
+        avertissements.extend(
+            f"{o['annee']} {o['num_adm']}/org{o['num_org']} : coCategorie inconnue `{l['cat']}` ({l['per']:g} pér.)"
+            for l in inconnues
+        )
+
+        tot_pe_gen += pe_g
+        tot_pep_gen += pep_g
+        tot_per += per_g + sum(l["per"] for l in auto)
+        tot_pe_auto += pe_a
+        tot_pep_auto += pep_a
+
+        if pe_g or pe_a:
+            lignes_ue.append({
+                "annee": o["annee"], "num_adm": o["num_adm"], "num_org": o["num_org"],
+                "niv": niv, "flag_ie": o["flag_ie"],
+                "per": per_g + sum(l["per"] for l in auto),
+                "pe": pe_g + pe_a, "pep": pep_g + pep_a, "libelle": o["libelle"],
+            })
+
+    moyenne = (tot_pep_gen + tot_pep_auto) / tot_per if tot_per else 0.0
+    pep_cp = sum(l["per"] for _, l in cas_particuliers) * moyenne
+    return {
+        "annee": annee_civile, "lignes_ue": lignes_ue, "cas_particuliers": cas_particuliers,
+        "a_confirmer": a_confirmer, "avertissements": avertissements,
+        "pe_gen": tot_pe_gen, "pep_gen": tot_pep_gen, "pe_auto": tot_pe_auto,
+        "pep_auto": tot_pep_auto, "periodes": tot_per, "moyenne": moyenne,
+        "pep_cp": pep_cp, "pep_total": tot_pep_gen + tot_pep_auto + pep_cp,
+    }
+
+
+def rendre_markdown(r):
+    n = r["annee"]
+    md = [
+        f"# Calcul détaillé des périodes-élèves pondérées (PEP) — année civile {n}",
+        "",
+        f"> Généré le {date.today().isoformat()} par `examples/calcul_pep_annee_civile.py` (pyetnic, lecture seule).",
+        "> Méthode : spec 21 (décret 16/04/1991 art. 99 + arrêté GCF 22/11/2002 art. 3-4).",
+        "",
+        "## Synthèse",
+        "",
+        "| Grandeur | Valeur |",
+        "|---|---:|",
+        f"| PE non pondérées (cas généraux + autonomie) | {r['pe_gen'] + r['pe_auto']:,.1f} |",
+        f"| Périodes organiques (cas généraux + autonomie) | {r['periodes']:,.1f} |",
+        f"| PEP cas généraux | {r['pep_gen']:,.2f} |",
+        f"| PEP part d'autonomie | {r['pep_auto']:,.2f} |",
+        f"| **Moyenne PEP/période** | **{r['moyenne']:.3f}** |",
+        f"| PEP cas particuliers ({sum(l['per'] for _, l in r['cas_particuliers']):g} pér. × moyenne) | {r['pep_cp']:,.2f} |",
+        f"| **PEP TOTAL établissement — année civile {n}** | **{r['pep_total']:,.2f}** |",
+        "",
+        "## Détail par UE — cas généraux + autonomie",
+        "",
+        f"| Année scol. | UE/org | Niv. | Pér. {n} | PE | PEP | IE |",
+        "|---|---|---|---:|---:|---:|---|",
+    ]
+    for u in sorted(r["lignes_ue"], key=lambda u: -u["pep"]):
+        md.append(
+            f"| {u['annee']} | {u['num_adm']}/{u['num_org']} — {u['libelle'][:48]} | {u['niv']} "
+            f"| {u['per']:g} | {u['pe']:g} | {u['pep']:.1f} | {u['flag_ie'] or ''} |"
+        )
+    md += ["", "## Cas particuliers — valorisés à la moyenne PEP/période", "",
+           f"| Année scol. | UE/org | Cat. | Pér. {n} | PEP | Activité |",
+           "|---|---|---|---:|---:|---|"]
+    for o, l in sorted(r["cas_particuliers"], key=lambda t: (t[0]["num_adm"], t[0]["num_org"])):
+        md.append(
+            f"| {o['annee']} | {o['num_adm']}/{o['num_org']} — {o['libelle'][:35]} | {l['cat']} "
+            f"| {l['per']:g} | {l['per'] * r['moyenne']:.1f} | {l['nom'][:40]} |"
+        )
+    if r["a_confirmer"]:
+        md += ["", "## Catégories à confirmer (PSup/PRET) — non comptées", ""]
+        md += [f"- {o['annee']} {o['num_adm']}/org{o['num_org']} : `{l['cat']}` {l['per']:g} pér."
+               for o, l in r["a_confirmer"]]
+    md += ["", "## Avertissements et limites", ""]
+    md += [f"- ⚠️ {w}" for w in r["avertissements"]]
+    md += [
+        "- Les élèves « redevables DI non en ordre de paiement » ne sont pas exclus (majorant).",
+        "- Arrondis officiels (2ᵉ décimale par étape) non répliqués — écart attendu ≈ ±0,5 %.",
+        "- Étapes 5-6 de l'arrêté (neutralisation, dépassements) hors périmètre (dotation de référence hors API).",
+        "",
+    ]
+    return "\n".join(md)
+
+
+def main():
+    parser = argparse.ArgumentParser(description="PEP computation for a civil year (read-only).")
+    parser.add_argument("annee_civile", type=int, help="civil year, e.g. 2025")
+    parser.add_argument("-o", "--output", help="markdown output path (default: rapport_pep_<year>.md)")
+    args = parser.parse_args()
+
+    logging.basicConfig(level=logging.WARNING)
+    resultat = calculer(args.annee_civile)
+    sortie = Path(args.output or f"rapport_pep_{args.annee_civile}.md")
+    sortie.write_text(rendre_markdown(resultat), encoding="utf-8")
+    print(f"PEP total {args.annee_civile} : {resultat['pep_total']:.2f} (moyenne {resultat['moyenne']:.3f})")
+    print(f"rapport : {sortie}")
+
+
+if __name__ == "__main__":
+    main()

--- a/rapport_pep_2025.md
+++ b/rapport_pep_2025.md
@@ -1,0 +1,251 @@
+# Calcul détaillé des périodes-élèves pondérées (PEP) — année civile 2025
+
+> Établissement 3052 — calcul reproduit par pyetnic (lecture seule, prod) selon la spec
+> `specs/21_calcul_encadrement_dotation.md` (décret 16/04/1991 art. 99 + arrêté GCF 22/11/2002 art. 3-4).
+> Généré le 2026-06-11 (session 9ter).
+
+## Méthode et intrants
+
+- **Assiette civile 2025** = périodes **réelles An2** des Doc 2 de 2024-2025 + périodes **réelles An1** des Doc 2 de 2025-2026 (207 organisations lues).
+- **PE** = périodes réelles × `nbEleveC1` (élèves du Doc 2, comptage 1ᵉʳ dixième).
+- **Coefficient pédagogique** par `coCategorie` : `referentiels/coefficients_ponderation_coCategorie.csv`.
+- **Coefficient de niveau** dérivé du `codeFormation` (segment `Uxx`) : U1x → B (1,0), U2x → A (1,25), U3x → C (1,5).
+- **Part d'autonomie** (`Auto`) : répartie au prorata des périodes des cas généraux **du dossier pédagogique** (`nbPeriodeBranche`, hérite leurs coefficients) — base indispensable pour les organisations sur deux années scolaires, où l'autonomie peut tomber dans une année civile sans cours généraux (ex. 510/org1 2024-2025 : 58 pér. CTln en 2024, 24 pér. d'autonomie en 2025).
+- **Limitation organique** : les périodes réelles du Doc 2 sont supposées ne couvrir que la part dotation (constat session 9ter : `réelles = prévues − IE` sur les UE mixtes) ; les UE 100 % IE ont des réelles nulles et ne contribuent pas.
+- **Cas particuliers** (encadrement, EPT, suivi) : périodes × moyenne PEP/période de l'établissement (étape 4 de l'arrêté).
+
+## Synthèse
+
+| Grandeur | Valeur |
+|---|---:|
+| PE non pondérées (cas généraux + autonomie) | 54,409.5 |
+| Périodes organiques (cas généraux + autonomie) | 4,913.5 |
+| PEP cas généraux | 73,104.30 |
+| PEP part d'autonomie | 17,312.29 |
+| **Moyenne PEP/période** | **18.402** |
+| PEP cas particuliers (639 pér. × moyenne) | 11,758.67 |
+| **PEP TOTAL établissement — année civile 2025** | **102,175.26** |
+
+## Détail par UE — cas généraux + autonomie
+
+| Année scol. | UE/org | Niv. | Pér. 2025 | PE | PEP | IE |
+|---|---|---|---:|---:|---:|---|
+| 2024-2025 | 312/1 — BASES DE LA SOUDURE T.I.G. | A | 120 | 1560 | 4875.0 |  |
+| 2024-2025 | 519/1 — SOUDURE SEMI-AUTOMATIQUE : NIVEAU 2 | A | 150 | 1350 | 4320.0 |  |
+| 2024-2025 | 408/1 — INFORMATIQUE:GESTIONNAIRE DE BASE DE DONNEES-NIV | A | 80 | 1600 | 3200.0 |  |
+| 2024-2025 | 455/1 — CONNAISSANCES DE GESTION DE BASE | A | 122 | 2074 | 2592.5 |  |
+| 2024-2025 | 511/2 — INFORMATIQUE : MAINTENANCE SOFTWARE | A | 76 | 1216 | 2432.0 |  |
+| 2024-2025 | 561/1 — APPROCHE CONCEPTUELLE METIERS AIDE & SOINS AUX P | A | 140 | 1260 | 2266.9 |  |
+| 2024-2025 | 528/4 — LANGUE : FRANCAIS UF 1 - NIVEAU ELEMENTAIRE | B | 120 | 2160 | 2160.0 |  |
+| 2024-2025 | 455/2 — CONNAISSANCES DE GESTION DE BASE | A | 157 | 1570 | 1962.5 |  |
+| 2025-2026 | 523/1 — BASES DE SOUDAGE ET DU COUPAGE OXYACETYLENIQUES | B | 80 | 800 | 1880.0 |  |
+| 2024-2025 | 565/2 — AIDE-SOIGNANT : APPROCHE CONCEPTUELLE | A | 160 | 1440 | 1800.0 |  |
+| 2024-2025 | 564/1 — AIDE-SOIGNANT : METHODOLOGIE APPLIQUEE | A | 178 | 1068 | 1681.5 |  |
+| 2024-2025 | 591/1 — UTILISATION D'UN SMARTPHONE | A | 40 | 840 | 1680.0 |  |
+| 2025-2026 | 556/1 — DECOUVERTE DES METIERS DE L'AIDE ET DES SOINS AU | A | 24 | 816 | 1632.0 |  |
+| 2024-2025 | 405/2 — INFORMATIQUE:EDITION ASSISTEE PAR ORDINATEUR-NIV | A | 40 | 800 | 1600.0 |  |
+| 2024-2025 | 406/2 — INFORMATIQUE : TABLEUR -NIVEAU ELEMENTAIRE | A | 40 | 800 | 1600.0 |  |
+| 2024-2025 | 407/1 — INFORMATIQUE:PRESENTATION ASSISTEE PAR ORD-NIVEA | A | 40 | 800 | 1600.0 |  |
+| 2024-2025 | 522/1 — SOUDURE A L'ARC AVEC ELECTRODE ENROBEE : NIVEAU  | B | 46 | 598 | 1534.0 |  |
+| 2024-2025 | 482/1 — LANGUE : ANGLAIS UF 1 - NIVEAU ELEMENTAIRE | B | 84 | 1512 | 1512.0 |  |
+| 2025-2026 | 564/1 — AIDE-SOIGNANT : METHODOLOGIE APPLIQUEE | A | 106 | 954 | 1503.0 |  |
+| 2024-2025 | 403/3 — INFORMATIQUE:LOGICIEL GRAPHIQUE D'EXPLOITATION | A | 40 | 720 | 1440.0 |  |
+| 2024-2025 | 528/2 — LANGUE : FRANCAIS UF 1 - NIVEAU ELEMENTAIRE | B | 120 | 1440 | 1440.0 |  |
+| 2024-2025 | 537/1 — PROGRAMMATION : NIVEAU 1 | A | 88 | 704 | 1408.0 |  |
+| 2024-2025 | 528/3 — LANGUE : FRANCAIS UF 1 - NIVEAU ELEMENTAIRE | B | 120 | 1320 | 1320.0 |  |
+| 2025-2026 | 511/2 — INFORMATIQUE : MAINTENANCE SOFTWARE | A | 72 | 648 | 1296.0 |  |
+| 2025-2026 | 549/1 — AIDE-SOIGNANT:ACTUAL DES ACT INFIRM DELEG:ASP TH | A | 48 | 768 | 1248.0 |  |
+| 2024-2025 | 492/2 — LANGUE FRANCAIS - UF 3 - NIVEAU INTERMEDIAIRE | A | 120 | 960 | 1200.0 |  |
+| 2024-2025 | 588/1 — INITIATION A L'ANGLAIS INFORMATIQUE - UE1 | B | 60 | 1140 | 1140.0 |  |
+| 2025-2026 | 528/3 — LANGUE : FRANCAIS UF 1 - NIVEAU ELEMENTAIRE | B | 76 | 1140 | 1140.0 |  |
+| 2024-2025 | 405/4 — INFORMATIQUE:EDITION ASSISTEE PAR ORDINATEUR-NIV | A | 40 | 560 | 1120.0 |  |
+| 2024-2025 | 523/1 — BASES DE SOUDAGE ET DU COUPAGE OXYACETYLENIQUES | B | 48 | 528 | 1102.2 |  |
+| 2024-2025 | 483/1 — LANGUE : ANGLAIS UF 2 - NIVEAU ELEMENTAIRE | B | 84 | 1092 | 1092.0 |  |
+| 2025-2026 | 326/1 — COMMUNICAT°:EXPRESS° OR & ECRITE APPLIQUEE AU SE | A | 68 | 544 | 1088.0 |  |
+| 2024-2025 | 557/1 — COMMUNICATION:EXPR OR & EXRITE APP AU SECT DU SE | A | 60 | 540 | 1080.0 |  |
+| 2024-2025 | 406/1 — INFORMATIQUE : TABLEUR -NIVEAU ELEMENTAIRE | A | 40 | 520 | 1040.0 |  |
+| 2024-2025 | 497/1 — INFORMATIQUE : RESEAUX - INTERNET/INTRANET | A | 40 | 520 | 1040.0 |  |
+| 2025-2026 | 524/1 — SOUDURE SEMI-AUTOMATIQUE : NIVEAU 1 | B | 46 | 552 | 1027.2 |  |
+| 2025-2026 | 510/1 — INFORMATIQUE : MAINTENANCE HARDWARE | A | 64 | 512 | 1024.0 |  |
+| 2025-2026 | 511/1 — INFORMATIQUE : MAINTENANCE SOFTWARE | A | 30 | 510 | 1020.0 |  |
+| 2024-2025 | 403/1 — INFORMATIQUE:LOGICIEL GRAPHIQUE D'EXPLOITATION | A | 24 | 504 | 1008.0 |  |
+| 2024-2025 | 549/1 — AIDE-SOIGNANT:ACTUAL DES ACT INFIRM DELEG:ASP TH | A | 34 | 544 | 992.0 |  |
+| 2024-2025 | 500/1 — INFORMATIQUE : TECHNOLOGIE DES RESEAUX | A | 40 | 480 | 960.0 |  |
+| 2024-2025 | 403/2 — INFORMATIQUE:LOGICIEL GRAPHIQUE D'EXPLOITATION | A | 24 | 480 | 960.0 |  |
+| 2024-2025 | 596/1 — POSE DE SYSTEMES D'EGOUTTAGE ET DE DRAINAGE PERI | B | 50 | 450 | 936.0 |  |
+| 2025-2026 | 528/2 — LANGUE : FRANCAIS UF 1 - NIVEAU ELEMENTAIRE | B | 116 | 928 | 928.0 |  |
+| 2025-2026 | 537/1 — PROGRAMMATION : NIVEAU 1 | A | 34 | 442 | 884.0 | K |
+| 2024-2025 | 328/5 — INFORMATIQUE : INTRODUCTION A L'INFORMATIQUE | A | 20 | 400 | 800.0 |  |
+| 2024-2025 | 405/3 — INFORMATIQUE:EDITION ASSISTEE PAR ORDINATEUR-NIV | A | 40 | 400 | 800.0 |  |
+| 2024-2025 | 492/1 — LANGUE FRANCAIS - UF 3 - NIVEAU INTERMEDIAIRE | A | 120 | 600 | 750.0 |  |
+| 2025-2026 | 522/1 — SOUDURE A L'ARC AVEC ELECTRODE ENROBEE : NIVEAU  | B | 42 | 420 | 744.0 |  |
+| 2024-2025 | 326/2 — COMMUNICAT°:EXPRESS° OR & ECRITE APPLIQUEE AU SE | A | 44 | 352 | 704.0 |  |
+| 2024-2025 | 510/2 — INFORMATIQUE : MAINTENANCE HARDWARE | A | 44 | 352 | 704.0 |  |
+| 2024-2025 | 510/1 — INFORMATIQUE : MAINTENANCE HARDWARE | A | 24 | 336 | 672.0 |  |
+| 2025-2026 | 492/1 — LANGUE FRANCAIS - UF 3 - NIVEAU INTERMEDIAIRE | A | 76 | 532 | 665.0 |  |
+| 2024-2025 | 157/2 — ESS - METHODES DE TRAVAIL | A | 40 | 320 | 640.0 |  |
+| 2025-2026 | 328/3 — INFORMATIQUE : INTRODUCTION A L'INFORMATIQUE | A | 20 | 320 | 640.0 |  |
+| 2024-2025 | 524/1 — SOUDURE SEMI-AUTOMATIQUE : NIVEAU 1 | B | 34 | 306 | 617.0 |  |
+| 2025-2026 | 483/1 — LANGUE : ANGLAIS UF 2 - NIVEAU ELEMENTAIRE | B | 44 | 616 | 616.0 |  |
+| 2024-2025 | 498/1 — INFORMATIQUE : INTRODUCTION A LA TECHNOLOGIE DES | A | 40 | 480 | 600.0 |  |
+| 2025-2026 | 328/4 — INFORMATIQUE : INTRODUCTION A L'INFORMATIQUE | A | 20 | 300 | 600.0 |  |
+| 2024-2025 | 511/4 — INFORMATIQUE : MAINTENANCE SOFTWARE | A | 32 | 288 | 576.0 |  |
+| 2024-2025 | 499/1 — INFORMATIQUE : SYSTEME D'EXPLOITATION | A | 40 | 280 | 560.0 |  |
+| 2025-2026 | 455/1 — CONNAISSANCES DE GESTION DE BASE | A | 80 | 400 | 500.0 |  |
+| 2024-2025 | 501/1 — INFORMATIQUE : UTILITAIRES COMPLEMENTAIRES AU SY | A | 40 | 240 | 480.0 |  |
+| 2024-2025 | 490/2 — LANGUE : FRANCAIS UF 2 - NIVEAU ELEMENTAIRE | B | 120 | 480 | 480.0 |  |
+| 2024-2025 | 395/1 — REV GEN BAR:FORM COMPL ACCES ECHEL D4 OUV QUAL D | B | 15 | 450 | 450.0 | C |
+| 2024-2025 | 511/1 — INFORMATIQUE : MAINTENANCE SOFTWARE | A | 16 | 224 | 448.0 |  |
+| 2025-2026 | 523/2 — BASES DE SOUDAGE ET DU COUPAGE OXYACETYLENIQUES | B | 28 | 252 | 446.4 |  |
+| 2024-2025 | 565/1 — AIDE-SOIGNANT : APPROCHE CONCEPTUELLE | A | 84 | 336 | 420.0 |  |
+| 2025-2026 | 328/2 — INFORMATIQUE : INTRODUCTION A L'INFORMATIQUE | A | 20 | 200 | 400.0 |  |
+| 2024-2025 | 327/2 — MATHEMATIQUES APPLIQUEES | A | 44 | 308 | 385.0 |  |
+| 2025-2026 | 403/3 — INFORMATIQUE:LOGICIEL GRAPHIQUE D'EXPLOITATION | A | 12 | 192 | 384.0 |  |
+| 2024-2025 | 328/4 — INFORMATIQUE : INTRODUCTION A L'INFORMATIQUE | A | 20 | 180 | 360.0 |  |
+| 2025-2026 | 403/2 — INFORMATIQUE:LOGICIEL GRAPHIQUE D'EXPLOITATION | A | 12 | 180 | 360.0 |  |
+| 2024-2025 | 593/1 — CESS : FRANCAIS - NIVEAU 1 | A | 40 | 280 | 350.0 |  |
+| 2025-2026 | 328/1 — INFORMATIQUE : INTRODUCTION A L'INFORMATIQUE | A | 20 | 160 | 320.0 |  |
+| 2025-2026 | 402/2 — MATHEMATIQUES APPLIQUEES A L'INFORMATIQUE | A | 36 | 252 | 315.0 |  |
+| 2025-2026 | 589/1 — INITIATION A L'ANGLAIS INFORMATIQUE - UE2 | B | 32 | 288 | 288.0 |  |
+| 2025-2026 | 482/1 — LANGUE : ANGLAIS UF 1 - NIVEAU ELEMENTAIRE | B | 40 | 280 | 280.0 |  |
+| 2025-2026 | 157/1 — ESS - METHODES DE TRAVAIL | A | 16 | 128 | 256.0 |  |
+| 2025-2026 | 406/1 — INFORMATIQUE : TABLEUR -NIVEAU ELEMENTAIRE | A | 16 | 128 | 256.0 |  |
+| 2024-2025 | 396/1 — REV GEN BAR:FORM COMPL ACCES ECHEL D4 OUV QUAL D | B | 8 | 248 | 248.0 | C |
+| 2025-2026 | 405/1 — INFORMATIQUE:EDITION ASSISTEE PAR ORDINATEUR-NIV | A | 16 | 112 | 224.0 |  |
+| 2024-2025 | 589/2 — INITIATION A L'ANGLAIS INFORMATIQUE - UE2 | B | 24 | 216 | 216.0 |  |
+| 2024-2025 | 563/1 — INITIATION AUX PREMIERS SECOURS | A | 20 | 100 | 200.0 |  |
+| 2025-2026 | 563/1 — INITIATION AUX PREMIERS SECOURS | A | 20 | 100 | 200.0 |  |
+| 2024-2025 | 402/1 — MATHEMATIQUES APPLIQUEES A L'INFORMATIQUE | A | 16 | 144 | 180.0 |  |
+| 2025-2026 | 396/1 — REV GEN BAR:FORM COMPL ACCES ECHEL D4 OUV QUAL D | B | 10 | 150 | 150.0 | C |
+| 2024-2025 | 570/1 — INTRO A LA SECU & A L'HYGIENE METIERS PARACHEV D | B | 12 | 108 | 108.0 |  |
+| 2025-2026 | 327/1 — MATHEMATIQUES APPLIQUEES | A | 12 | 84 | 105.0 |  |
+| 2024-2025 | 568/1 — FORM CONT AG TECH DES ADM LOC & REG-SEC SPEC A L | A | 10.5 | 73.5 | 91.9 | C |
+| 2025-2026 | 568/1 — FORM CONT AG TECH DES ADM LOC & REG-SEC SPEC A L | A | 5 | 50 | 62.5 | C |
+
+## Cas particuliers — valorisés à la moyenne PEP/période
+
+Moyenne PEP/période = 18.402
+
+| Année scol. | UE/org | Cat. | Pér. 2025 | PEP | Activité |
+|---|---|---|---:|---:|---|
+| 2025-2026 | 402/1 — MATHEMATIQUES APPLIQUEES A L'INFORM | ExPT | 40 | 736.1 | EXPERTISE PEDAGOGIQUE ET TECHNIQUE |
+| 2025-2026 | 403/1 — INFORMATIQUE:LOGICIEL GRAPHIQUE D'E | ExPT | 1 | 18.4 | EXPERTISE PEDAGOGIQUE ET TECHNIQUE |
+| 2024-2025 | 403/5 — INFORMATIQUE:LOGICIEL GRAPHIQUE D'E | ExPT | 179 | 3293.9 | EXPERTISE PEDAGOGIQUE ET TECHNIQUE |
+| 2024-2025 | 403/6 — INFORMATIQUE:LOGICIEL GRAPHIQUE D'E | ExPT | 99 | 1821.8 | EXPERTISE PEDAGOGIQUE ET TECHNIQUE |
+| 2024-2025 | 512/1 — STAGE : TECHNICIEN EN INFORMATIQUE | CTen | 39 | 717.7 | ENCADREMENT DU STAGE DU TECHNICIEN EN IN |
+| 2025-2026 | 512/1 — STAGE : TECHNICIEN EN INFORMATIQUE | CTen | 4 | 73.6 | ENCADREMENT DU STAGE DU TECHNICIEN EN IN |
+| 2024-2025 | 513/1 — EPREUVE INTEGREE DE LA SECTION: "TE | CTen | 15 | 276.0 | PREPA EI SECTION "TECHNICIEN EN INFORMAT |
+| 2024-2025 | 513/1 — EPREUVE INTEGREE DE LA SECTION: "TE | CTen | 4 | 73.6 | EI SECTION "TECHNICIEN EN INFORMATIQUE" |
+| 2024-2025 | 550/1 — AIDE-SOIGNANT:ACTUAL DES ACT INFIRM | PPen | 20 | 368.0 | A-I:ACTU ACT INFIR DEL:ENCADREMENT DU ST |
+| 2024-2025 | 550/1 — AIDE-SOIGNANT:ACTUAL DES ACT INFIRM | PPen | 12 | 220.8 | A-I:ACTU ACT INFIR DEL:ENCADREMENT DE LA |
+| 2024-2025 | 560/1 — STAGE D'OBSERVATION METIERS DE L'AI | PPen | 59 | 1085.7 | ENCADREMENT STAGE D'OBSERVATION METIERS  |
+| 2025-2026 | 560/1 — STAGE D'OBSERVATION METIERS DE L'AI | PPen | 4 | 73.6 | ENCADREMENT STAGE D'OBSERVATION METIERS  |
+| 2024-2025 | 562/1 — STAGE D'INSERTION METIERS DE L'AIDE | PPen | 60 | 1104.1 | ENCADREMENT STAGE D'INSERTION |
+| 2025-2026 | 566/1 — AIDE-SOIGNANT : STAGE D'INTEGRATION | PPen | 12 | 220.8 | AIDE-SOIGNANT : ATELIER DE PRATIQUE REFL |
+| 2024-2025 | 566/2 — AIDE-SOIGNANT : STAGE D'INTEGRATION | PPen | 40 | 736.1 | AIDE-SOIGNANT : STAGE D'INTEGRATION:ENCA |
+| 2025-2026 | 566/2 — AIDE-SOIGNANT : STAGE D'INTEGRATION | PPen | 4 | 73.6 | AIDE-SOIGNANT : STAGE D'INTEGRATION:ENCA |
+| 2024-2025 | 567/1 — EPREUVE INTEGREE DE LA SECTION : "A | CTen | 19 | 349.6 | PREPARATION EI |
+| 2024-2025 | 567/1 — EPREUVE INTEGREE DE LA SECTION : "A | CTen | 4 | 73.6 | EI DE LA SECTION:"AIDE-SOIGNANT" |
+| 2024-2025 | 608/1 — AIDE FAMILIAL : STAGE D'INTEGRATION | PPen | 4 | 73.6 | ENCADREMENT DE STAGE |
+| 2025-2026 | 608/1 — AIDE FAMILIAL : STAGE D'INTEGRATION | PPen | 16 | 294.4 | ENCADREMENT DE STAGE |
+| 2025-2026 | 608/1 — AIDE FAMILIAL : STAGE D'INTEGRATION | SEtu | 4 | 73.6 | ADMISSION, SUIVI PEDAGOGIQUE ET SANCTION |
+
+## Confrontation aux chiffres officiels (HOD/CICS, écrans 57L/57D — 11/06/2026)
+
+L'utilisateur a extrait du système hôte (transaction `MENP052`, écrans `PMM5DM1` 57L « Liste des
+périodes-élèves » et `PMM5EM1` 57D « Détail périodes-élèves par école », établissement **9017001**
+EICA Auvelais) les **PE officielles (encadrement)** par année civile :
+
+| An. civ. | PE élèves (officiel) | dont chef d'atelier | Emplois calculés (new) |
+|---:|---:|---:|---|
+| 2018 | 90 270 | 20 647 | — |
+| 2019 | 90 349 | 21 435 | — |
+| 2020 | 95 100 | 21 815 | — |
+| 2021 | 78 238 | 18 629 | — |
+| 2022 | 79 785 | 19 538 | — |
+| 2023 | 77 878 | 18 692 | — |
+| 2024 | 106 369 | 22 886 | dir. 1,00 · surv. 1,50 |
+| **2025** | **99 748** | **18 526** | dir. 1,00 · surv. 1,50 |
+| 2026 (partiel) | 28 204 | 7 970 | — |
+
+⚠️ **PE ≠ PEP** : ces 99 748 PE (encadrement) ne sont pas comparables aux 102 175 PEP du présent
+rapport (proximité fortuite). La bonne comparaison est avec une **reconstruction des PE encadrement** :
+PE organiques toutes catégories (57 772,5) + cas particuliers à la moyenne PE/période (≈ 3 521) +
+**interventions extérieures** (≈ 28 895, élèves estimés par le max des lignes d'activité) ≈ **90 189 PE**,
+soit 90,4 % du chiffre officiel dans cette première approche. L'écart a été **localisé puis expliqué**
+(précision utilisateur) : **11 organisations VC/convention** (455 « Connaissances de gestion » VC ×5,
+528/1 FLE, 403/7, 510/2 et 4, 546/1) portent **1 005 périodes IE 2025 sans aucun élève** — ni lignes
+d'activité Doc 2, ni population Doc 1, ni inscriptions SEPS (tous vérifiés ; la recherche SEPS
+fonctionne par ailleurs : 490/1 → 7 inscriptions ✓). Ce sont des activités de type **EPT (expertise
+pédagogique et technique)** prestées sous convention/VC : **l'absence d'élèves y est normale**, et
+ces périodes se valorisent comme les cas particuliers, à la **moyenne PE/période** de l'établissement
+(même logique que l'étape 4 de l'arrêté côté PEP).
+
+**Reconstruction corrigée** : PE lignes avec élèves (57 772,5) + IE avec élèves (28 895,5) +
+(319 pér. réservées organiques + 1 005 pér. EPT) × moyenne PE/période :
+
+| Variante de moyenne | Moyenne | Total PE | vs officiel 99 748 |
+|---|---:|---:|---:|
+| organique (PE org / pér. org) | 11,039 | 101 284 | +1,54 % |
+| globale (PE org+IE / pér. org+IE) | 10,634 | **100 748** | **+1,00 %** |
+
+Résidu de ~1 % attribuable aux exclusions DI non payés (majorant connu), aux arrondis officiels et à
+la définition exacte de la moyenne (assiette, arrondi 2ᵉ décimale).
+
+## Validation officielle — écran 55L (dotations / PEP, HOD 11/06/2026)
+
+Second extrait utilisateur : transaction `MENP052`, écran **55L** (`PMM5BM1`, « Liste dotations
+périodes par an. civile ») — c'est l'écran « pot K » : dotation organique + **PEP officielles** :
+
+| An. civ. | Dot. initiale | Dot. utilisable | Solde | PEP référence | PEP calculée | % |
+|---:|---:|---:|---:|---:|---:|---:|
+| 2018 | 6 772 | 6 348 | 4 | 128 235 | 126 658 | −1,23 |
+| 2019 | 6 772 | 6 338 | −20 | 128 235 | 115 089 | −10,25 |
+| 2020 | 6 772 | 6 327 | −10 | 115 084 | 126 821 | +10,20 |
+| 2021 | 6 598 | 6 150 | 1 | 117 340 | 98 586 | −15,98 |
+| 2022 | 6 598 | 6 169 | — | 98 586 | 92 447 | −6,23 |
+| 2023 | 6 598 | 6 440 | −12 | 98 586 | 95 307 | −3,33 |
+| 2024 | 6 598 | 7 210 | 3 | 98 586 | 108 214 | +9,77 |
+| **2025** | 6 598 | 6 572 | −4 | 98 635 | **101 710** | **+3,12** |
+| 2026 | 6 601 | 6 595 | 4 782 | — | 30 111 (partiel) | — |
+
+🎯 **PEP calculée officielle 2025 = 101 710 vs 102 175,26 pyetnic → écart +0,46 %** (+465 PEP).
+Candidats pour le résidu : élèves DI non payés non exclus (majorant connu), arrondis officiels
+(2ᵉ décimale par étape), valorisation fine des cas particuliers.
+
+**Mécanismes vérifiés sur la série** (calculs exacts) :
+- `% = (calculée − référence) / référence` — exact sur les 8 années.
+- **Décalage N → N+2** : PEP calculées de l'année N ajustent la dotation de N+2 (« avant-dernière
+  année civile », arrêté art. 2) — ex. calc 2019 (−10,25 %) → baisse dotation 2021.
+- **Baisse = ¼ × dotation × |%|** : ¼ × 6 772 × 10,25 % = 173,5 ≈ 174 périodes retirées (6 772 → 6 598).
+  ⚠️ **Le plafond de 50 périodes (arrêté art. 6) n'a pas été appliqué** — à clarifier (version de
+  l'arrêté applicable en 2021 ?).
+- **Neutralisation ±8 %** observée : 2022 (−6,23), 2023 (−3,33), 2025 (+3,12) → dotation inchangée.
+- **Hausse** : calc 2024 (+9,77 %) → dotation 2026 = 6 601 (+3 seulement — redistribution limitée au
+  disponible, enveloppe fermée).
+- **Référence re-proratisée à la dotation** après ajustement : 98 586 × 6 601/6 598 = 98 631 ≈ 98 635.
+
+→ **Prévision dotation 2027** : calc 2025 = +3,12 % (dans ±8 %) → dotation inchangée (≈ 6 601).
+
+## Réconciliation de l'assiette — rapport 4 « Doc2 : périodes organiques » (ppm_1614, éd. 2425 + 2526)
+
+Assiette organique officielle de l'année civile 2025 : **4 126,5** pér. réelles (col. « réel 25 »,
+édition 2425) + **1 426,0** (édition 2526) = **5 552,5 périodes organiques**. Décomposition exacte :
+**4 913,5** pér. de cas généraux + autonomie et **639** pér. de cas particuliers — soit, **à la période
+près**, l'assiette du présent rapport. La couche d'entrée du calcul PEP est donc validée à 100 % ;
+le résidu de +0,46 % sur les PEP relève de la pondération/des arrondis officiels, pas de l'assiette.
+(Le rapport 4 ne contient pas le bloc des interventions extérieures : « périodes organiques » =
+lignes d'activité du Doc 2, ce qui confirme définitivement l'hypothèse « réelles = part dotation ».)
+
+**Assiette IE également réconciliée** (`ppm_2003` B87, éditions 2425 + 2526) : IE civil 2025 =
+1 982,5 + 1 939,0 = **3 921,5 périodes = lecture SOAP exacte** (C 2 554,5 · I 598 · F 289 · K 181 ·
+V 299). Le `PPM_2002` (« IE de type EPT ») est **vide** : les sessions sans élèves sont des IE
+ordinaires, pas des EPT — le résidu PE encadrement (±1 %) relève donc uniquement de leur mode de
+valorisation (élèves/moyenne), toutes les assiettes étant désormais validées à 100 %.
+
+## Avertissements et limites
+
+- Les élèves « redevables DI non en ordre de paiement » devraient être exclus (specs 16/19) — non vérifiable via Doc 2 seul (croisement SEPS possible).
+- L'arrêté (art. 4, 1°) base l'ajustement sur les périodes **prévues** de l'avant-dernière année civile ; ce rapport utilise les périodes **réelles** (PEP effectivement générées, décret art. 99). Écart possible si prévu ≠ réel.
+- Étapes 5-6 de l'arrêté (neutralisation des augmentations, corrections de dépassement) non applicables sans la dotation de référence (hors API, « pot K »).
+- Volume EPT 2025 : 319 périodes (plafond 10 % de la dotation organique à vérifier hors API).

--- a/specs/00_SUIVI_SESSIONS.md
+++ b/specs/00_SUIVI_SESSIONS.md
@@ -292,7 +292,281 @@ décrites structurellement, extraction CSV possible ultérieurement si besoin.
 
 ---
 
-### Session 8 — (à planifier) : Synthèse + Architecture + Mock server
+### Session 8 — 2026-06-10 : Circulaires légales (DI, calendrier, hybride, renseignements annuels)
+
+**Documents analysés** :
+- ✅ Circulaire **9217** du 03/04/2024 (DI 2024-2025) — texte intégral via miroir ICC Bruxelles
+  (Gallilex/enseignement.be bloquent l'accès automatisé — WAF ; PDF Gallilex téléchargés manuellement
+  dans `circulaires/`)
+- ✅ Circulaire **9488** du 16/04/2025 (DI 2025-2026) — montants via synthèse GHA-WBE
+- ✅ Circulaire **9731** du 27/05/2026 (DI **2026-2027**, en vigueur) — `circulaires/53231_0000.pdf`
+- ✅ Circulaire **9487** du 16/04/2025 (calendrier EA 2025-2026, dotation) — `circulaires/52387_0000.pdf`
+- ✅ Circulaire **8829** du 01/02/2023 (enseignement hybride, AGCF 21/12/2022) — `circulaires/50609_000.pdf`
+- ✅ Circulaire **8684** du 16/08/2022 (**Renseignements annuels** : instructions d'encodage EPROM,
+  toujours en vigueur) — `circulaires/49854_000.pdf` (90 p.)
+
+**Fichiers produits** :
+- `specs/16_circulaires_droit_inscription.md` — formule DI (forfait + tarif×min(p,800), montants
+  2024→2027), assiette (dossier pédagogique, 1ᵉʳ dixième), exonérations ↔ `MotifExemptionType`,
+  recalcul global multi-établissements + remboursement, arrondi, règle Doc 1D « constaté ≠ perçu » (9731)
+- `specs/17_circulaire_9487_calendrier_dotation.md` — année académique, congés, **100 % planifiés /
+  90 % dispensés**, dotation par année civile (découpage 16+24 semaines), numérotation des semaines
+- `specs/18_circulaire_8829_hybride.md` — hybride : organisation distincte, neutralité dotation/DI,
+  bascule 48 h, **« DOC A » = déclaration d'ouverture**
+- `specs/19_circulaire_8684_renseignements_annuels.md` — instructions complètes Doc A/1/2/1D/3 :
+  sémantique des colonnes, règles de cohérence, lignes 91-96, regroupements, IE, échéancier
+- Renvois croisés ajoutés dans `02`, `03`, `04`, `05`, `06`, `11` ; registre (`20102`) mis à jour
+
+**Découvertes clés** :
+- ⭐ **« Doc A » = document Organisation (déclaration d'ouverture EPROM)** — confirmé deux fois
+  (8829 §Encodage du Document A ; 8684 §2.1 « Déclaration d'organisation DOCUMENT A »). Hypothèse
+  « Doc A = Doc 1 » des sessions 4-5 **corrigée** ; chaîne `20102` : Organisation + Doc 2 approuvés
+  → Doc 3.
+- ⭐ **Les web services EPROM (Doc A, 2, 1D, 3) sont officiellement documentés** dans la 8684 comme
+  canal pour les applications de gestion (ENORA, GIPS, PROSOC…).
+- **Règle 100 %/90 %** (9487) : prévu Doc 2 = 100 % du Doc 8bis ; réel ≥ 90 % (CO/VH réputées
+  dispensées, pas VA/VD/VP/VE) → explique `nbPeriodesPrevuesDoc2`/`nbPeriodesReellesDoc2`.
+- **Dotation gérée par année civile** (16+24 semaines) → explique la ventilation an 1 / an 2 des
+  périodes du Doc 2 (`nbPerAn1`/`nbPerAn2`).
+- **Règles de multiples** (8684) : réel = multiple entier du prévu ; total = multiple entier **ou
+  entier-et-demi** du Doc 8bis (→ les périodes sont des `float`) ; encadrement = effectif ×
+  périodes/étudiant ; total 18+19 = plafond des attributions Doc 3 (`1574`).
+- **Recalcul global du DI** multi-établissements avec obligation de remboursement → helper pyetnic
+  sur l'ensemble des inscriptions de l'année. Assiette DI = dossier pédagogique, pas le Doc 2.
+- **DI 2026-2027** : 34 € / 0,30 (sec) / 0,47 (sup), plafond 800 ; nouvelle exonération boursiers
+  BES AeSI ; VA désormais régie par la circ. **9447** (25/02/2025).
+- Lignes spéciales Doc 2 : 91-94 valorisation (92/94 encodables jusqu'au 31/10 N+1 après
+  approbation !), 95 expertise (≥40 p./chargé de cours), 96 suivi pédagogique (sans DI ni population —
+  Doc 1/1D à valider vides).
+- Échéancier : Doc A ≤ 5 j ouvrables ; Doc 1+2 ≤ 35 j (1ᵉʳ dixième) ; Doc 1D ≤ 25 j (5ᵉ dixième) ;
+  Doc 3 ≤ 35 j (approbation Doc 2).
+
+**Points restants** : « colonnes A et B » du Doc 1 (réf. des circulaires DI) non élucidées (annexes 7-8
+de la 8684 = manuels HOD/CICS-EPROM à dépouiller au besoin) ; test TQ du déclencheur `20102` ;
+mapping fin exonérations ↔ C01-C07 ; circulaires connexes non traitées : 9448 (inclusif, périodes
+complémentaires), 9447 (VA), 6351 (activités de formation), 4462/6677 (conventions).
+
+---
+
+### Session 9 — 2026-06-10 : Exploration de l'application EPROM Web (lecture seule)
+
+**Méthode** : navigation dans l'application de production (`EPROM_WEB` 2.12.0, IBM Faces) via Chrome
+piloté en JavaScript (les boutons exigent des séquences de `MouseEvent` réels ; notes techniques
+complètes dans la spec 20 §3). Compte école EICA, année 2024-2025, formation témoin 157.
+
+**Fichier produit** : `specs/20_exploration_ui_eprom.md` + mises à jour specs 05/16/19.
+
+**Confirmations / résolutions** :
+- ⭐ **Doc A définitivement confirmé** = l'organisation : tableau « DOCUMENTS ANNUELS » de l'UI
+  (Doc A / Doc 1 et 2 / Doc 1D / Doc 3 avec statuts « Approuvé » / « Encodé école » = `StatutCT`).
+  « Doc 1 et 2 » = une entrée à 2 statuts → cohérent avec `statutDocumentPopulationPeriodes` unique.
+- ⭐ **« Colonnes A et B » résolu** : colonnes UI « Elèves A » (col 2) / « Elèves B » (col 5) du Doc 1.
+- ⭐ **Référentiels `teStatut` et `coDispo` extraits avec libellés** depuis les listes déroulantes du
+  Doc 3 (60 codes dispo ; 7 statuts ACS/ACS DP/Déf. Accessoire/Définitif/Expert/eXpertise/Temporaire).
+- Tuple `(O - O - O - O - E)` de la liste = statuts des 5 documents (A, 1, 2, 1D, 3).
+- Champs UI = mapping 1:1 avec `FormationOrganisationCT` (dont « conseiller en prévention ou DPO »),
+  `Doc3ActiviteDetailCT`/`Doc3EnseignantDetailCT`, colonnes 12-19 du Doc 2 ventilées **par année
+  civile** dans les en-têtes (« Prévue 2024 / Prévue 2025 / Réel 2024 / Réel 2025 »).
+- **Lignes 97-99 du Doc 2** découvertes (97 PeSu périodes suppl., 98 PSup part supplémentaire,
+  99 CEtu conseil des études) — absentes de la 8684.
+- Onglet IE : périodes par année civile en 3 lignes « Cas généraux / Cas particuliers / Suppléments ».
+
+---
+
+### Session 9bis — 2026-06-10 : Calcul de l'encadrement et de la dotation de périodes (spec 21)
+
+**Déclencheur** : question utilisateur — pyetnic peut-il calculer la dotation d'une école à partir de ses chiffres ?
+
+**Fichier produit** : `specs/21_calcul_encadrement_dotation.md`.
+
+**Découvertes clés** :
+- ⭐ **Deux grandeurs distinctes** (précision utilisateur) : **encadrement** (équipe administrative) = sur
+  **périodes-élèves (PE)** ; **dotation de périodes** (rémunération enseignants) = **PE *pondérées*** (coefficients par catégorie).
+- **Aucun service SOAP analysé** ne renvoie la dotation/encadrement (vérifié : 0 champ `dotation/encadrement/NTPP`
+  dans WSDL/XSD). La **dotation de base** est communiquée par l'administration (juillet, par année civile ;
+  consultée historiquement via HOD/CICS « pot K », écran 59).
+- **Cadre du calcul localisé** : décret 16/04/1991 **art. 82-93, 102, 111 §1, 115** ; **arrêté GCF 22/11/2002**
+  (ajustements) ; **arrêté 09/07/2004** + circ. **5447** (part d'autonomie ≈ 20 %) ; circulaires **PS 327/96**
+  (calcul PE + cas particuliers encadrement), **PS 402/03** (ajustements), **PS 357/98 / 422/06** (expertise,
+  périodes suppl.) ; le tout recensé par la circulaire-**répertoire 2816 du 13/07/2009**.
+- **Décret coordonné déposé et analysé** (`circulaires/16184_0036.pdf`, MAJ 19/12/2025, 71 p., texte natif) →
+  **verbatim confirmé** : **PE = périodes réellement organisées × élèves réguliers, sommées** (art. 99) ;
+  **catégories A (sec. sup.) / B (sec. inf.) / C (supérieur)** (art. 83) = axe de pondération ; norme
+  **30 000/40 000 PE** (art. 100, « autonomie de l'établissement », ≠ part d'autonomie du dossier péda) ;
+  période **50 min** (art. 82) ; dotation **par année civile** (art. 86) ; **déductions** (art. 87bis) ;
+  **réserve + dépassement 1,5×** (art. 91/93) ; **plafond 10 %** activités hors cours, **≤ 1 %** formation (art. 91/6) ;
+  expertise **40-800 périodes** (art. 91/4) ; **supplément suivi pédagogique** 100/200/300/400/500 **périodes B**
+  selon PE générées (30k/120k/240k/360k/500k, art. 36 §2 — ⚠️ corrige une table provisoire erronée).
+- ⭐ **Arrêté GCF 22/11/2002 obtenu** (numac 2003029045, version coordonnée Justel 18/08/2025) → **table de pondération
+  verbatim** : coef. pédagogique **1 / 1,6 / 2,8** × coef. niveau **B=1 / A=1,25 / C=1,5 / D=1,8** ; PE pondérées en
+  6 étapes (cas généraux / part d'autonomie au prorata / organique / cas particuliers / neutralisation augmentations /
+  dépassements) ; ajustement par **intervalle de neutralisation ±8 %**, baisse plafonnée à **50 périodes**, redistribution
+  au prorata (enveloppe fermée). Base = **avant-dernière année civile** ; dotation de référence = année précédente.
+- **Faisabilité pyetnic** : le calcul est désormais **entièrement spécifié** → simulateur/vérificateur complet ; seul
+  intrant non récupérable par service = la **dotation de référence** (communiquée par l'administration). Recommander un
+  module « financement » paramétrable par millésime (coefficients, ±8 %, plafond 50, plafonds 10 %/1 %).
+
+- **Table de pondération figée** : `referentiels/coefficients_ponderation_coCategorie.csv` — 30 codes `coCategorie`
+  (spec 04) → coefficient pédagogique (1 / 1,6 / 2,8), croisés avec l'arrêté art. 3 (15 cas généraux ; 1 autonomie ;
+  12 cas particuliers à la moyenne PEP/période ; 2 à confirmer : `PSup`, `PRET`).
+
+**Points mineurs restants** : catégorie « D » du barème (1,8) vs « D » abrogé du décret en 2021 (à clarifier) ;
+taux exact part d'autonomie (arrêté 09/07/2004) ; `coCategorie` `PSup`/`PRET` (2/30) ; modèle d'annexe de l'arrêté. **Aucun bloquant.**
+PDF arrêté : `ejustice.just.fgov.be/img_l/pdf/2002/11/22/2003029045_F.pdf` (à déposer dans `circulaires/` si souhaité).
+
+---
+
+### Session 9ter — 2026-06-11 : Test prod — UE hors PEP 2024-2025 (limitation organique, Doc 2)
+
+**Déclencheur** : question utilisateur — quelles UE ne sont pas comptabilisées pour les PEP en 2024-2025 ?
+
+**Test prod (lecture seule, étab 3052)** : `lister_formations` + `lire_organisation` + `lire_document_2`
+sur les **123 organisations** de 2024-2025 (110 formations). Scripts jetables `/tmp/pep_*.py`.
+
+**Résultats** :
+- **45/123 organisations** financées hors dotation (toutes avec `interventionExterieure50p = true`) :
+  **32 Convention (C)**, **9 Publics infra-scolarisés (I)**, **3 Validation des compétences (V)**,
+  **1 Fonds Européens (F)** — soit **3 691,5 périodes IE** sur 7 986,5 prévues déclarées.
+- ⭐ **Cohérence parfaite** flag organisation (`typeInterventionExterieure`) ↔ lignes IE du Doc 2 :
+  zéro divergence sur 123 organisations (le flag est un résumé fiable des lignes IE).
+
+**Patterns d'encodage Doc 2 découverts (constat prod, à généraliser avec prudence)** :
+1. **IE totale (« miroir »)** : total périodes activités = total périodes IE (ex. 490 : 120 = 120) → UE
+   entièrement hors dotation, zéro PEP.
+2. **IE partielle 50 %** (395, 396, 568) : `nbTotPeriodeReelle = nbTotPeriodePrevue − périodes IE`
+   (ex. 395 : 30 prévues, 15 IE, 15 réelles) → 🔶 hypothèse : les **périodes réelles** du Doc 2 ne
+   comptent que la **part dotation** ; les périodes IE vivent uniquement sur leurs lignes propres.
+3. **Placeholder** (403/4·7, 455/3-6, 510/3-4, 511/3, 528 — VC et conventions) : activités déclarées à
+   **0,5 ou 1 période symbolique**, tout le volume réel porté par les lignes IE (ex. 455/3 : 0,5 prévue,
+   300 IE) → ⚠️ le total activités du Doc 2 **n'est pas une assiette fiable** seul ; toujours croiser
+   avec `interventionExterieureListe`.
+4. **IE composite** : 518/org1 a `typeInterventionExterieure = F` mais **deux lignes** Doc 2
+   (`F/WL` = 105 + `K/PR` = 105) → le flag organisation ne reflète que le type dominant.
+
+**Impact spec 21** : note de lecture ajoutée à l'étape 3 (limitation organique) — l'exclusion des
+périodes hors dotation est calculable par organisation via les lignes IE du Doc 2.
+
+**Suite (même session) — premier calcul PEP complet, année civile 2025** (`rapport_pep_2025.md`) :
+chaîne spec 21 exécutée de bout en bout sur la prod (lecture seule, 207 organisations des années
+scolaires 2024-2025 + 2025-2026). Assiette civile 2025 = réelles An2 (24-25) + réelles An1 (25-26).
+⭐ **Coefficient de niveau dérivable du `codeFormation`** (segment `Uxx` : U1x → B, U2x → A, U3x → C —
+validé sur 971111U21D2 « ESS »). Résultat : **102 175 PEP** (73 104 cas généraux + 17 312 autonomie +
+11 759 cas particuliers à la moyenne 18,40 PEP/période ; 4 913,5 périodes organiques ; 54 409 PE).
+Aucun `PSup`/`PRET` rencontré. Limites consignées dans le rapport (élèves = `nbEleveC1`, DI non payé
+non exclu, prévu vs réel art. 4, étapes 5-6 hors API).
+⭐ **Règle de calcul confirmée par l'utilisateur (organisations bi-annuelles)** : le prorata de la part
+d'autonomie se base sur la **structure du dossier pédagogique** (`nbPeriodeBranche` des cas généraux),
+pas sur la tranche civile — cas 510/org1 2024-2025 (08/04/2024 → 28/01/2025, `org2AnneesScolaires`) :
+58 pér. CTln réelles en civil 2024, 24 pér. d'autonomie en civil 2025 → les 24 héritent du coef CTln
+(1,6 × 1,25) bien qu'aucun cours général ne tombe en 2025.
+
+⭐ **Écrans officiels HOD identifiés (captures utilisateur, 11/06/2026)** : transaction `MENP052`,
+écrans **57L** (`PMM5DM1`, liste PE par année civile 2018-2027) et **57D** (`PMM5EM1`, détail par
+école — PE, chef d'atelier, emplois calculés dir./s-dir./surv./chef at., régimes « anciens »/« new »).
+PE officielles EICA 2025 = **99 748** (chef at. 18 526) ; série complète dans `rapport_pep_2025.md`.
+⚠️ PE (encadrement) ≠ PEP (dotation) — la proximité avec les 102 175 PEP calculées est fortuite.
+**Validation** : reconstruction PE encadrement pyetnic (organique 57 772 + cas part. ≈ 3 521 +
+IE ≈ 28 895) = **90 189 ≈ 90,4 % de l'officiel** ; écart attribué aux élèves des UE conventionnées
+(absents du Doc 2 → croiser Doc 1/SEPS). Complète la mention « pot K écran 59 » de la spec 19.
+
+🎯 **Écran 55L (« pot K ») extrait également** (`PMM5BM1`, « Liste dotations périodes par an. civile ») :
+dotation organique initiale/utilisable/solde + **PEP référence/calculée/%** depuis 2018.
+**PEP calculée officielle 2025 = 101 710 vs 102 175 pyetnic → +0,46 %** — la chaîne spec 21 est
+**validée de bout en bout**. Mécanismes vérifiés exactement sur la série : décalage **N → N+2**,
+neutralisation **±8 %** (2022/2023/2025), hausse 2026 = +3 pér. (enveloppe fermée, calc 2024 +9,77 %),
+baisse 2021 = **¼ × 6 772 × 10,25 % = 174 pér.** (🔶 **plafond 50 non appliqué** — à clarifier),
+référence re-proratisée à la dotation (98 586 × 6 601/6 598 ≈ 98 635). Prévision dotation 2027 :
+inchangée (+3,12 % dans ±8 %). Série complète dans `rapport_pep_2025.md`.
+
+⭐ **Écart PE encadrement expliqué** (capture UI Doc 2 web de la 490 + précision utilisateur) : les UE
+conventionnées « miroir » portent bien leurs élèves (490 : 7 él. cohérents Doc 1/Doc 2/SEPS) ; les
+**11 organisations VC/convention sans élèves** (455 VC ×5, 528/1, 403/7, 510/2+4, 546/1 — 1 005 pér.
+IE 2025, aucune population Doc 1/Doc 2/SEPS, vérifié) sont des activités de type **EPT** : pas
+d'élèves par nature → valorisées à la **moyenne PE/période** comme les cas particuliers.
+Reconstruction corrigée : **100 748 PE (+1,0 % vs officiel 99 748)** avec la moyenne globale
+(10,634 PE/pér.) — résidu ≈ DI non payés + arrondis. **Règle PE encadrement complète** :
+PE = Σ(pér. × élèves) [lignes avec élèves, IE comprises] + (pér. réservées + pér. EPT) × moyenne.
+⭐ Au passage, l'UI Doc 2 web (onglet Intervention extérieure) confirme **en prod** la table
+`coCodePar` de la spec 04 (`CG`/`CP`/`SU`, ventilés par année civile) et l'équivalence des colonnes
+UI avec l'annexe 8684 (col. 12-19, spec 19).
+
+⭐ **Rapport hôte `ppm_1614` extrait** (« Documents 2 - Année scolaire 2526 », 27 p., 11/06/2026) —
+vue mainframe des Doc 2 par UE/organisation, colonnes prévu/réel **ventilées par année civile**
+(25/26/TOTAL) + élèves + flag `App`. **Données identiques au SOAP** (sondages : 537/1, 568/1, 396/1,
+564/1 — exacts). Confirmations majeures :
+1. **Réelles = part dotation, prouvé verbatim** : 568/1 (CTni 10→5, 6→3 ; Auto 9→4,5) et 396/1
+   (20→10 ; Auto 4→2) — toutes les réelles = 50 % des prévues sur les UE convention mixtes ;
+   réelles = 0 sur les conventions 100 % (qui gardent prévues + élèves).
+2. **Placeholders = prévues d'EPT** : ligne 95, prévu symbolique (0,5/1) et **réel = volume effectif**
+   (403/1 : 1,00 prévu → 160 réel dont 159 en civil 2026 ; 402/1 : 1 → 40).
+3. **Sémantique `PRET` élucidée** : lignes « PRESTATION ETUDIANT (stage/EI) » en tête des UE
+   stage/épreuve intégrée — heures prestées par l'étudiant, **toujours 0** chez EICA → relevé pour
+   mémoire, pas de valorisation observée (CSV mis à jour, valorisation à confirmer).
+4. **Numérotation standard des cas particuliers** : lignes **91-94** VAF/VANFI (`SEtu`), **95** `ExPT`,
+   **96** `SEtu` admission/suivi/sanction, **97** `PeSu`, **98** `PSup`, **99** `CEtu` — correspond aux
+   `coNumBranche` 91-99 renvoyés par le SOAP, gabarit présent sur toutes les UE.
+5. **`App` = `swAppD2`** (O/blanc — les blancs correspondent exactement aux Doc 2 non approuvés).
+6. 🔶 **537/1 (flag K)** : les 80 périodes « octroi cabinet-projets transversaux » apparaissent en
+   **ligne 96 SEtu prévues** (= les 80 pér. du bloc IE K en SOAP) — mapping type IE → ligne cas
+   particulier à creuser.
+
+⭐ **Inventaire du menu hôte A5** (`PMM02M1`, « Année scolaire - Documents annuels ») — rapports
+extractibles pour les sessions futures : 1 Documents annuels en attente d'encodage · 2 DI et DIO
+encodés /école/formation · 3 Périodes utilisées /formation/école · **4 Doc2 : périodes organiques** ·
+**5 Doc2 : EPT organiques** · **6 Int.Ext. : périodes organisées** · **7 Int.Ext. : EPT** ·
+8 Organisations illicites · **9 IE /école/projet/année civile** · A Recherche **pots d'heures**/groupe
+(fonction) · B Catalogue **pots d'heures**/groupe(fonction) · C Doc1 : population scolaire.
+→ Le système distingue nativement **EPT organique** (5) et **EPT en intervention extérieure** (7) —
+exactement la dichotomie identifiée pour l'écart PE ; les « pots d'heures » (A/B) sont la matérialisation
+du « pot K » (spec 19). Extractions prioritaires : 4+5 (assiette organique PEP), 6+7+9 (valorisation IE,
+résidu ~1 000 PE, mapping K→ligne 96), C (élèves comptabilisés / exclusions DI).
+
+**Extractions reçues (suite, 11/06/2026 — les autres rapports vides ou indisponibles)** :
+- ⭐ **`ppm_1613` (A55) « Périodes EPT » 2526** = la liste officielle des **EPT organiques** : 402/1
+  (40 pér. réelles 2025) + 403/1 (1 pér. 2025 + 159 pér. 2026) — **exactement** l'assiette EPT 25-26
+  du calcul pyetnic (41 pér. civil 2025 ✓). Attendu dans l'édition 2425 : 403/5 (179) + 403/6 (99)
+  → total EPT organique 2025 = 319 = l'assiette « réservées » du rapport PEP. **Confirme aussi que
+  les sessions VC/convention sans élèves ne sont PAS des EPT organiques.**
+- ⭐ **`PPM_2002` « IE de type EPT » : vide même correctement relancé** → l'école n'a **aucune IE de
+  type EPT** officiellement. Les sessions VC/convention sans élèves sont des **IE ordinaires (C/V/K)** ;
+  la question du résidu PE (~1 000) se joue à la valorisation (élèves/moyenne), pas au classement.
+- ⭐ **`ppm_2003` (B87) « Liste des Interventions Extérieures »** (éditions 2425 + 2526) — la vue
+  officielle des blocs IE du Doc 2 : type (= `coCatCol`), **sous-cat (= `coObjFse`** : FO, WL, FP, SP,
+  IN, PR), **agrément**, **projet global** (22516, 22976, 21651… = la « Référence » de l'UI), périodes
+  an.1/an.2, classement par **niveau SI/SS**. **Réconciliation exacte** : IE civil 2025 = 1 982,5
+  (an.2 éd. 2425) + 1 939,0 (an.1 éd. 2526) = **3 921,5 pér. = lecture SOAP à l'identique** (2 916,5
+  avec élèves + 1 005 sans). Par type : C 2 554,5 · I 598 · F 289 · K 181 · V 299. Enseignements :
+  (1) **le type d'IE est attaché au projet et à l'année scolaire** — 522/2, 523/3, 524/2 passent de
+  `I` (FO 1096/21651) en 2425 à `C` (FO 1153/22550) en 2526 ; (2) **une UE peut cumuler deux types**
+  (518/1 : F/WL **et** K/PR sur le même projet 18690 « 3-3111RE », 105 + 105 pér.) ; (3) K se décline
+  en sous-cat SP (537/1) et IN (546/1).
+
+**Décision d'architecture (validée par l'utilisateur)** : le moteur de calcul PE/PEP reste **hors de
+pyetnic** (conforme spec 21 §7 — pyetnic = client SOAP fidèle, la logique réglementaire vivra dans un
+projet dédié, p.ex. la future application école). Les scripts validés sont promus en **démonstrations**
+dans `examples/` : `calcul_pep_annee_civile.py` (PEP d'une année civile + rapport markdown, reproduit
+102 175,26 pour 2025 ✓) et `calcul_pe_encadrement.py` (PE encadrement, reproduit 100 747,6 ✓) —
+paramétrés par année civile, prorata autonomie sur `nbPeriodeBranche`, niveau via `codeFormation`.
+- ⭐ **Rapport 4 « Doc2 : périodes organiques » reçu pour 2425 + 2526** : c'est le `ppm_1614`
+  (l'extraction précédente 2526 l'était déjà) — il ne contient **pas** le bloc IE, confirmant que
+  « périodes organiques » = lignes d'activité du Doc 2. **Réconciliation exacte de l'assiette
+  civile 2025** : officiel = 4 126,5 (réel25, éd. 2425) + 1 426,0 (réel25, éd. 2526) = **5 552,5 pér.
+  organiques réelles** = **4 913,5 (cas généraux + autonomie) + 639 (cas particuliers) pyetnic — à
+  la période près**. La couche d'entrée du calcul PEP est validée à 100 % ; le résidu PEP (+0,46 %)
+  ne peut venir que de la pondération/arrondis officiels, plus de l'assiette. (Édition 2425 :
+  EPT 403/5 = 1+179, 403/6 = 1+99 ✓ ; conventions 50 % : 395/396/568 réelles = moitié des prévues ✓.)
+- ⭐ **`ppm_1544` « Documents 1 : Population scolaire par organisation »** (éditions 2425 + 2526) —
+  vue Doc 1 + Doc 1D fusionnée : colonnes annexe 8684 (2)-(10'), **montants DI/DIO perçus par
+  organisation** et **comptage au 5/10ᵉ** (`nb elv 5/10`). Enseignements : (1) les organisations
+  **placeholder VC/convention n'apparaissent même pas** dans le rapport officiel (455/3-6, 510/3-4,
+  528/1, 403/5-7 absents — cohérent avec Doc 1/SEPS vides) ; (2) les conventions « miroir » portent
+  leurs élèves surtout en col. (8) « comptés plusieurs fois » ; (3) les organisations **bi-annuelles
+  figurent dans les DEUX éditions** (157/2-2425 = 157/1-2526, mêmes dates) ; (4) totaux officiels :
+  2425 = **1 285 comptés / 1 060 au 5/10ᵉ**, 2526 (partiel) = 647/550.
+
+---
+
+### Session 10 — (à planifier) : Synthèse + Architecture + Mock server
 
 **À faire** :
 - Synthèse cross-services (EPROM + **SEPS**)
@@ -302,12 +576,13 @@ décrites structurellement, extraction CSV possible ultérieurement si besoin.
 - Intégrer les **référentiels** (pays/communes) comme données embarquées + helpers de validation
 
 **Points à trancher / confirmer (hérités des sessions précédentes)** :
-- **Mapping « Doc A »** : confirmer formellement que le « Doc A » de l'erreur `20102` (Doc 3) = Document 1
-  (Population). Le Doc 1D (session 5) **ne mentionne pas « Doc A »** → hypothèse inchangée. Nomenclature
-  interne consolidée : Doc 1 (Population), Doc 1D (Droits), Doc 2 (Périodes), Doc 3 (Attributions), Doc 8bis.
-  Reconstituer la chaîne d'approbation : Organisation → Population (Doc A/1) + Périodes (Doc 2) →
-  Attributions (Doc 3) ; **Droits d'Inscription (Doc 1D) = branche indépendante** (pas de `20102`, workflow
-  interne population→montants).
+- **Mapping « Doc A »** : ✅ **résolu en session 8** (circulaire 8829, spec 18) — « Doc A » =
+  **document Organisation (déclaration d'ouverture EPROM)**, pas le Document 1. Chaîne corrigée :
+  Organisation (Doc A, `StatutCT` Approuvé) + Périodes (Doc 2, `swAppD2`) → Attributions (Doc 3) ;
+  Population (Doc 1) et Droits (Doc 1D) = workflows propres non bloquants. Reste : test TQ de
+  confirmation (approuver Organisation+Doc 2 sans Doc 1, appeler Doc 3). Nomenclature consolidée :
+  Doc A (Organisation), Doc 1 (Population), Doc 1D (Droits), Doc 2 (Périodes), Doc 3 (Attributions),
+  Doc 8bis (dossier pédagogique/horaire).
 - **Divergences de type périodes** : décider de la stratégie zeep pour les champs `xs:int` recevant des
   valeurs « 24.0 » (Doc 3 : `nbPeriodesDoc8`, `nbPeriodesPrevuesDoc2`, `nbPeriodesReellesDoc2`).
   ⚠️ **Spécifique au Doc 3** : le Doc 1D n'a pas ce problème (`nbEleves5ieme` vrai `int`, montants `float`).
@@ -340,6 +615,11 @@ décrites structurellement, extraction CSV possible ultérieurement si besoin.
 | Circulaire de rentrée 2025-2026 — MDP Enseignement pour Adultes | 9589 du 19/09/2025 | ✅ session 6 | ✅ `07_circulaire_9589_contexte_personnel.md` + `08_circulaire_9589_ea12_attributions.md` |
 | Circulaire dossier personnel étudiant / matricule / DI / présences (EA) | 9593 du 23/09/2025 | ✅ session 7 | ✅ `14_circulaire_9593_dossier_personnel.md` |
 | Référentiels codes pays / nationalités / communes INS | Catalogue SOA ETNIC | ✅ session 7 | ✅ `15_referentiels_seps.md` + `referentiels/*.csv,json` |
+| Circulaires DI annuelles (calcul, exonérations, déclaration) | 9217 / 9488 / 9731 | ✅ session 8 | ✅ `16_circulaires_droit_inscription.md` |
+| Calendrier général EA + gestion dotation de périodes | 9487 du 16/04/2025 | ✅ session 8 | ✅ `17_circulaire_9487_calendrier_dotation.md` |
+| Enseignement hybride (conditions, encodage Doc A) | 8829 du 01/02/2023 | ✅ session 8 | ✅ `18_circulaire_8829_hybride.md` |
+| Renseignements annuels (instructions encodage EPROM Doc A/1/2/1D/3) | 8684 du 16/08/2022 | ✅ session 8 (annexes 7-8 partiellement) | ✅ `19_circulaire_8684_renseignements_annuels.md` |
+| Calcul de l'encadrement & de la dotation de périodes (PE, pondération, autonomie) | décret 16/04/1991 art. 82-93 + arrêté 22/11/2002 + PS 327/96, 402/03 (répertoire 2816) | ✅ session 9bis (cadre ; verbatim à confirmer 🔶) | ✅ `21_calcul_encadrement_dotation.md` |
 
 ## Services SEPS identifiés (Étudiants & Inscriptions — Enseignement pour Adultes)
 

--- a/specs/21_calcul_encadrement_dotation.md
+++ b/specs/21_calcul_encadrement_dotation.md
@@ -104,6 +104,16 @@ issue des dossiers / arrêté 09/07/2004 art. 7 ; circ. 5447 — 🔶 taux exact
 ### 5.1 Encadrement (équipe administrative)
 Calculé directement sur les **PE** (cas généraux + particuliers), sans pondération de catégorie. Sert à déterminer les charges du **personnel administratif / direction / auxiliaire d'éducation** (décret art. 35 pour le comptage des étudiants réguliers ; art. 82-93 pour l'encadrement). 🔶 (paramètres/seuils exacts à confirmer).
 
+⭐ **Source officielle (HOD/CICS, transaction `MENP052` — session 9ter)** : écrans **57L** (`PMM5DM1`,
+« Liste des périodes-élèves » par année civile, clé = n° administratif école, ex. 9017001) et **57D**
+(`PMM5EM1`, « Détail périodes-élèves par école ») — donnent les **PE officielles**, le sous-total
+**« chef d'atelier »** et les **emplois calculés/attribués/sur dépêche** en deux régimes (« anciens »
+et « new ») pour 4 fonctions : **direction, sous-direction, surveillance, chef d'atelier**.
+Points de calibration EICA : 2025 = 99 748 PE (18 526 chef at.) → dir. 1,00 + surv. 1,50 ;
+chef at. 0 malgré 18 526 PE (seuil non atteint). **Reconstruction pyetnic à +1,0 %** (100 748 PE) avec
+la règle : PE = Σ(pér. × élèves) [lignes avec élèves, **IE comprises**] + (pér. réservées + pér. **EPT
+sans élèves**, normales pour l'expertise) × **moyenne PE/période** — cf. `rapport_pep_2025.md`.
+
 ### 5.2 Dotation de périodes (rémunération des enseignants)
 
 **Unité & catégories (✅ décret)** : la dotation est exprimée en **périodes de 50 minutes** (art. 82, « périodes
@@ -139,6 +149,28 @@ PE pondérées(cours) = périodes-élèves(cours) × coefficient pédagogique ×
 | **C** (supérieur) | **1,5** |
 | **D** | **1,8** *(⚠️ « D » abrogé du décret en 2021 mais toujours présent au barème de l'arrêté — à clarifier)* |
 
+#### Table figée — `coCategorie` (Doc 2) → coefficient pédagogique
+
+> Croisement du référentiel `coCategorie` (spec 04, 30 codes) avec l'art. 3, 1° a) de l'arrêté. Fichier exploitable :
+> `referentiels/coefficients_ponderation_coCategorie.csv`. Le **coefficient de niveau** (B/A/C/D ci-dessus) s'applique
+> **en plus**, selon le niveau de l'UE (orthogonal à la catégorie).
+
+**Cas généraux** (génèrent des PEP avec leur coefficient propre) :
+
+| coef. | `coCategorie` |
+|---|---|
+| **1** | `CG` (cours généraux) · `CPPM` (psychopédagogie/méthodologie) · `CS` (cours spéciaux) · `CTin` (techniques industriels) · `CTni` (techniques non-industriels) |
+| **1,6** | `CGms` (généraux méth. spéciale) · `CGrn` (généraux remise à niveau) · `CSda` (spéciaux dactylo) · `CTms` (techniques méth. spéciale) · `CTli` (labo industriels) · `CTln` (labo non-industriels) · `CTPP` (techniques et pratique prof.) · `PPni` (pratique prof. non industrielle) |
+| **2,8** | `PPin` (pratique prof. industrielle) · `PPnu` (pratique prof. nursing) |
+
+**Part d'autonomie** : `Auto` → pas de coef propre, **réparti au prorata** des cas généraux (hérite leur coef ; cf. étape 2).
+
+**Cas particuliers** (pas de coef propre → valorisés à la **moyenne PEP/période**, étape 4) :
+`CGen` · `CSen` · `CTen` · `CTPe` · `PPen` (encadrement) · `CTst` · `PPst` (encadrement de stage 🔶) · `SEtu` (admission/suivi/sanction) · `CEtu` (conseil des études) · `ExPT` (expertise pédagogique et technique) · `PeSu` (périodes supplémentaires) · `CP` (générique).
+
+**🔶 À confirmer auprès de l'ETNIC** : `PSup` (part supplémentaire — cas général au prorata, ou cours à coef propre ?) ·
+`PRET` (prestations étudiant — rattachement/coef ?).
+
 **Définition des assiettes (art. 1)** :
 - **Cas généraux** = périodes des cours du dossier pédagogique **hors part d'autonomie et hors encadrement**.
 - **Cas particuliers** = encadrement, périodes supplémentaires, valorisation des acquis (formels/informels/non-formels),
@@ -148,10 +180,26 @@ PE pondérées(cours) = périodes-élèves(cours) × coefficient pédagogique ×
 **Calcul des PE pondérées d'un établissement (art. 4, procédure en 6 étapes)** :
 1. **Cas généraux** : cours par cours, PE pondérées générées par les **périodes prévues** de l'**avant-dernière année
    civile** (art. 2).
-2. **Part d'autonomie** : on ajoute ses PE pondérées — la part d'autonomie se **répartit au prorata des autres cours**
-   du dossier pédagogique.
+2. **Part d'autonomie** : on ajoute ses PE pondérées — la part d'autonomie se **répartit au prorata (des périodes)
+   des autres cours** du dossier pédagogique (les **cas généraux**, hors autonomie et hors cas particuliers).
+   ⭐ **Conséquence quand l'UE mélange des cours de natures différentes** : l'autonomie **n'a pas de coefficient propre** ;
+   sa quote-part allouée à chaque cours **hérite du coefficient (pédagogique × niveau) de ce cours**. Elle est donc
+   pondérée comme la **moyenne pondérée-par-périodes** des cours de l'UE.
+   *Ex. (Doc 2 UE 558) : activité 8 « AUTONOMIE » = 28 pér. réparties sur les 7 cours (112 pér.) → 28 × pér_cours/112,
+   chaque quote-part prenant le coef. de son cours (CTms, CTni, PPni…).*
+   ⭐ **Base du prorata = `nbPeriodeBranche` (structure du dossier), pas la tranche civile** (confirmé
+   utilisateur, session 9ter) : sur une organisation **bi-annuelle** (`numOrganisation2AnneesScolaires`,
+   spec 02), l'autonomie peut tomber dans une année civile sans aucun cours général — ex. 510/org1
+   2024-2025 (08/04/2024 → 28/01/2025) : 58 pér. CTln réelles en civil 2024, 24 pér. d'autonomie en
+   civil 2025, qui héritent du coef CTln (1,6 × niveau).
 3. **Limitation « organique »** : réduction au prorata des périodes **ne provenant pas** de la dotation de l'établissement
    → PE pondérées **organiques** par formation, totalisées.
+   ⭐ **Lecture Doc 2 (constat prod 2024-2025, session 9ter)** : les périodes hors dotation sont les lignes
+   `interventionExterieureListe` du Doc 2 (conventions `C`, infra-scolarisés `I`, validation des compétences `V`,
+   fonds européens `F`…) ; le flag organisation `typeInterventionExterieure`/`interventionExterieure50p` (spec 02)
+   les résume fidèlement (45/123 organisations, zéro divergence). ⚠️ Pièges d'encodage : UE « placeholder »
+   (activités à 0,5/1 période symbolique, volume réel sur les lignes IE) et 🔶 périodes **réelles** du Doc 2
+   qui semblent ne compter que la part dotation (`réelles = prévues − IE` sur les UE mixtes 50 %).
 4. **Cas particuliers** : ajout sur la base du **nombre moyen de PE pondérées par période** des activités hors cas
    particuliers. → chaque période d'un cas particulier « vaut » la **moyenne PE pondérées/période** de l'établissement.
    - **EPT = Expertise Pédagogique et Technique** (cas particulier ; = flag `organisationPeriodesSupplOuEPT` spec 02,
@@ -240,6 +288,14 @@ SEPS Inscriptions (spec 11-12)            EPROM Doc 1 / 1D (spec 03/06)
 
 **Non disponible via les web services** :
 - La **dotation de base / dotation de référence** (enveloppe de l'année précédente) — **communiquée par l'administration** (juillet, par année civile), historiquement consultée via le système hôte **HOD/CICS « pot K » (écran 59)**, hors API (spec 19). C'est le **seul intrant non récupérable** par service.
+  ⭐ **Écran localisé (session 9ter)** : transaction `MENP052`, écran **55L** (`PMM5BM1`, « Liste dotations
+  périodes par an. civile ») — dotation organique **initiale/utilisable/solde** + **PEP de référence /
+  calculée / %** par année civile (série depuis 2018 extraite, cf. `rapport_pep_2025.md`). Mécanismes
+  **vérifiés sur la série EICA** : décalage **N → N+2** ; neutralisation **±8 %** ; baisse **¼ × dotation
+  × |%|** (🔶 **observée SANS le plafond de 50 périodes** en 2021 : −174 pér. — version d'arrêté à
+  clarifier) ; **référence re-proratisée** à la dotation après ajustement (98 586 × 6 601/6 598 ≈ 98 635).
+  🎯 **Validation pyetnic** : PEP calculée officielle 2025 = **101 710** vs **102 175** reproduites
+  (+0,46 %).
 
 **Conclusion** : pyetnic peut désormais **reproduire le calcul** — périodes-élèves, **pondération** (table embarquée), encadrement, consommation, contrôle 90 %/100 %, plafonds Doc 3 — et **estimer la dotation** dès lors qu'on lui fournit la **dotation de référence** (saisie) et qu'on neutralise l'effet « enveloppe fermée » (l'ajustement inter-établissements ±8 % dépend des autres écoles, donc une **estimation par établissement** est exacte *à la dotation de référence + variation d'enveloppe près*). La **valeur officielle** reste celle de l'administration. Un module « financement » paramétrable par **millésime** (coefficients, ±8 %, plafond 50, plafonds 10 %/1 %) est recommandé, séparé du client SOAP.
 
@@ -263,9 +319,12 @@ Restent ouverts (mineurs, **non bloquants**) :
    l'art. 83 du décret en 2021** → clarifier ce que recouvre encore « D » (sortie en voie d'extinction ?).
 2. 🔶 **Arrêté GCF du 09/07/2004** (dossiers pédagogiques, art. 7) : **taux exact** de la part d'autonomie (≈ 20 %).
    Gallilex `textes-normatifs/40726` (à confirmer) ; circ. **5273**/**5447**.
-3. 🔶 **Modèle d'annexe** de l'arrêté 22/11/2002 (documents administratifs de calcul, art. 2) : utile pour le mapping
+3. 🔶 **`coCategorie` PSup (part supplémentaire) et PRET (prestations étudiant)** : seuls 2 codes sur 30 non tranchés
+   dans la table de pondération (`referentiels/coefficients_ponderation_coCategorie.csv`) — cas général au prorata vs
+   coef propre, à confirmer avec l'ETNIC.
+4. 🔶 **Modèle d'annexe** de l'arrêté 22/11/2002 (documents administratifs de calcul, art. 2) : utile pour le mapping
    exact avec les colonnes des Doc 1/2 (déjà largement couvert par les specs 19 et 20).
-4. ✅ **Actualisation EA** : décret coordonné 19/12/2025 et arrêté coordonné 18/08/2025 — **tous deux à jour**.
+5. ✅ **Actualisation EA** : décret coordonné 19/12/2025 et arrêté coordonné 18/08/2025 — **tous deux à jour**.
 
 ---
 
@@ -275,4 +334,5 @@ Restent ouverts (mineurs, **non bloquants**) :
 - **Arrêté GCF du 22/11/2002 (coordonné, MAJ 18/08/2025)** — règles d'ajustement + **table de pondération** (art. 1-7), source verbatim §5.2. [Justel](https://www.ejustice.just.fgov.be/eli/arrete/2002/11/22/2003029045/justel) · [PDF consolidé](https://www.ejustice.just.fgov.be/img_l/pdf/2002/11/22/2003029045_F.pdf) (à déposer dans `circulaires/` si souhaité).
 - [Enseignement.be — dossiers pédagogiques / part d'autonomie (circ. 5447/2015)](https://gallilex.cfwb.be/sites/default/files/imports/41427_000.pdf)
 - [Circulaire 4903 du 26/06/2014 — DI (redevables non payés exclus du calcul de l'encadrement / ajustement de la dotation)](https://gallilex.cfwb.be/sites/default/files/imports/39963_000.pdf)
+- **Table de pondération figée** : `referentiels/coefficients_ponderation_coCategorie.csv` (30 codes `coCategorie` → coefficient pédagogique, croisement spec 04 × arrêté art. 3).
 - Specs internes liées : `04_formation_periodes_v1.md`, `05_document3_v1.md`, `06_formation_droits_inscription_v1.md`, `16_circulaires_droit_inscription.md`, `17_circulaire_9487_calendrier_dotation.md`, `19_circulaire_8684_renseignements_annuels.md`.

--- a/specs/referentiels/coefficients_ponderation_coCategorie.csv
+++ b/specs/referentiels/coefficients_ponderation_coCategorie.csv
@@ -1,0 +1,31 @@
+code,libelle,coef_pedagogique,groupe,confiance,note
+CG,COURS GENERAUX,1,cas_general,haute,arrêté art.3 1°a i (cours généraux)
+CGms,COURS GENERAUX-methodologie speciale,1.6,cas_general,haute,arrêté art.3 1°a ii (cours généraux de méthodologie spéciale)
+CGrn,COURS GENERAUX-remise à niveau,1.6,cas_general,haute,arrêté art.3 1°a ii (cours généraux de remise à niveau)
+CPPM,COURS PSYCHO-PEDAGOGIE ET METHODOLOGIE,1,cas_general,haute,arrêté art.3 1°a i (psychopédagogie et méthodologie)
+CS,COURS SPECIAUX,1,cas_general,haute,arrêté art.3 1°a i (cours spéciaux)
+CSda,COURS SPECIAUX-dactylo,1.6,cas_general,haute,arrêté art.3 1°a ii (cours spéciaux de dactylographie)
+CTin,COURS TECHNIQUES industriels,1,cas_general,haute,arrêté art.3 1°a i (cours techniques industriels)
+CTni,COURS TECHNIQUES non industriels,1,cas_general,haute,arrêté art.3 1°a i (cours techniques non-industriels)
+CTms,COURS TECHNIQUES-methodologie speciale,1.6,cas_general,haute,arrêté art.3 1°a ii (cours techniques de méthodologie spéciale)
+CTli,COURS TECHNIQUES-labo industriels,1.6,cas_general,haute,arrêté art.3 1°a ii (travaux de laboratoire industriels)
+CTln,COURS TECHNIQUES-labo non industriels,1.6,cas_general,haute,arrêté art.3 1°a ii (travaux de laboratoire non-industriels)
+CTPP,COURS TECHNIQUES ET PRATIQUE PROFESSION.,1.6,cas_general,haute,arrêté art.3 1°a ii (cours techniques et de pratique professionnelle)
+PPni,PRATIQUE PROFESSION. non industrielle,1.6,cas_general,haute,arrêté art.3 1°a ii (pratique professionnelle non industrielle)
+PPin,PRATIQUE PROFESSIONNELLE industrielle,2.8,cas_general,haute,arrêté art.3 1°a iii (pratique professionnelle à caractère industriel)
+PPnu,PRATIQUE PROFESSION.-nursing,2.8,cas_general,haute,arrêté art.3 1°a iii (pratique professionnelle de nursing)
+Auto,AUTONOMIE,,autonomie,haute,part d'autonomie — pas de coef propre ; répartie au prorata des périodes des cas généraux (hérite leur coef) — arrêté art.4 2°
+CGen,COURS GENERAUX - encadrement,,cas_particulier_encadrement,haute,cas particulier (encadrement) — valorisé à la moyenne PEP/période (arrêté art.4 4°)
+CSen,COURS SPECIAUX-encadrement,,cas_particulier_encadrement,haute,cas particulier (encadrement) — moyenne PEP/période
+CTen,COURS TECHNIQUES-encadrement,,cas_particulier_encadrement,haute,cas particulier (encadrement) — moyenne PEP/période
+CTPe,COURS TECHN.& PRATIQUE PROF. - encadrement,,cas_particulier_encadrement,haute,cas particulier (encadrement) — moyenne PEP/période
+PPen,PRATIQUE PROFESSION.-encadrement,,cas_particulier_encadrement,haute,cas particulier (encadrement) — moyenne PEP/période
+CTst,COURS TECHNIQUES-stages,,cas_particulier_encadrement,moyenne,cas particulier (encadrement de stage) — moyenne PEP/période ; à confirmer
+PPst,PRATIQUE PROFESSION.-stages,,cas_particulier_encadrement,moyenne,cas particulier (encadrement de stage) — moyenne PEP/période ; à confirmer
+SEtu,"ADMISSION, SUIVI PEDAGOGIQUE, SANCTION",,cas_particulier,haute,cas particulier (suivi pédagogique / admission / sanction) — moyenne PEP/période
+CEtu,CONSEIL DES ETUDES,,cas_particulier,haute,cas particulier (conseil des études) — moyenne PEP/période
+ExPT,EXPERTISE PEDAGOGIQUE ET TECHNIQUE,,cas_particulier,haute,cas particulier (EPT) — moyenne PEP/période ; volume 40-800 pér. (décret art.91/4)
+PeSu,PERIODES SUPPLEMENTAIRES,,cas_particulier,haute,cas particulier (périodes supplémentaires) — moyenne PEP/période
+CP,Cas particuliers,,cas_particulier,haute,catégorie générique cas particulier — moyenne PEP/période
+PSup,PART SUPPLEMENTAIRE,,a_confirmer,faible,"part supplémentaire de l'horaire de référence — statut (cas général au prorata ? cours avec coef propre ?) à confirmer auprès de l'ETNIC"
+PRET,PRESTATIONS ETUDIANT,,a_confirmer,moyenne,"heures prestées par l'étudiant en stage/EI — lignes dédiées en tête des UE stage/épreuve intégrée (rapport hôte ppm_1614, session 9ter) ; toujours 0 chez EICA, relevé pour mémoire ; valorisation éventuelle à confirmer auprès de l'ETNIC"


### PR DESCRIPTION
## Summary

- Session 9ter: full execution of the spec 21 PE/PEP computation chain on production data (civil year 2025), reconciled with the official host screens/reports extracted from HOD/CICS.
- Calibration results: **PEP +0.46 %** (102 175.26 vs 101 710 official), **PE ±1 %** (vs 99 748), **organic and external-intervention assiettes exact** (5 552.5 and 3 921.5 periods).
- Adjustment mechanics verified on the official 2018-2026 series (N→N+2 lag, ±8 % neutralisation, ¼×|%| decrease, re-prorated reference) — one open point: the 50-period cap was not applied in 2021.
- Spec 21 enriched (autonomy prorata on `nbPeriodeBranche`, level from `codeFormation`, host reports inventory), `coCategorie` coefficient referential frozen as CSV, full computation report added (`rapport_pep_2025.md`).
- Two demo scripts promoted to `examples/` (PEP and PE by civil year); the financing engine itself stays **out of pyetnic** by design (spec 21 §7).

## Test plan

- [x] `examples/calcul_pep_annee_civile.py 2025` reproduces 102 175.26 (read-only run against prod)
- [x] `examples/calcul_pe_encadrement.py 2025` reproduces 100 747.6
- [x] No library code touched — docs, referential data and examples only

🤖 Generated with [Claude Code](https://claude.com/claude-code)